### PR TITLE
feat(vscode): snippets, hover docs link, explain quick-fix

### DIFF
--- a/tools/zpp_lsp.zig
+++ b/tools/zpp_lsp.zig
@@ -251,11 +251,14 @@ fn onHover(server: *Server, id_text: []const u8, params: ?std.json.Value) !void 
         if (hd.line != line) continue;
         if (character < hd.col_start or character > hd.col_end) continue;
         const explain_text = compiler.diagnostics.explain(hd.code);
-        // Format as a Markdown hover with the code id as the title.
+        // Format as a Markdown hover: title, explain block, and a docs link
+        // so users can jump to the canonical reference for this code.
+        const code_id_lower = try lowerAscii(server.allocator, hd.code.id());
+        defer server.allocator.free(code_id_lower);
         const md = try std.fmt.allocPrint(
             server.allocator,
-            "**{s}**\n\n```text\n{s}\n```",
-            .{ hd.code.id(), explain_text },
+            "**{s}**\n\n```text\n{s}\n```\n\n[See: docs/diagnostics#{s}](https://nktkt.github.io/zigpp-lang/language.html#{s})",
+            .{ hd.code.id(), explain_text, code_id_lower, code_id_lower },
         );
         defer server.allocator.free(md);
         const escaped = try jsonStringify(server.allocator, md);
@@ -449,6 +452,12 @@ fn countLines(s: []const u8) usize {
 }
 
 /// Allocates a JSON-quoted version of `s`, including surrounding quotes.
+fn lowerAscii(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
+    const out = try allocator.alloc(u8, s.len);
+    for (s, 0..) |c, i| out[i] = std.ascii.toLower(c);
+    return out;
+}
+
 fn jsonStringify(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
     var out = std.ArrayList(u8){};
     defer out.deinit(allocator);

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -24,6 +24,17 @@ official Zig extension.
   to the Zig++ output channel.
 - "Show lowered Zig" command that opens the result of `zpp lower` in a new
   untitled `.zig` editor so you can see exactly what the compiler emits.
+- **Snippets** for `trait`, `impl`, `owned struct`, `using`, `dyn`,
+  `derive`, `requires`, `ensures`, `effects`, `extern interface`, `own`,
+  and a `main` boilerplate. Type the prefix and press `Tab`.
+- **Hover with explanations**: hovering over a diagnostic line shows the
+  long-form explanation of the diagnostic code plus a link to the docs
+  site reference.
+- **Quick Fix code actions**: when the cursor is on a Zig++ diagnostic
+  (e.g. Z0010), VS Code's lightbulb offers `Zig++: Explain Z####` to
+  open the long-form text in the output channel.
+- "Explain Diagnostic Code" command (`Cmd/Ctrl+Shift+E`) for direct
+  lookup by code.
 - Bracket matching, auto-closing pairs, and word-pattern tuned for Zig
   identifiers.
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -45,6 +45,12 @@
         "path": "./syntaxes/zigpp.tmLanguage.json"
       }
     ],
+    "snippets": [
+      {
+        "language": "zigpp",
+        "path": "./snippets/zigpp.json"
+      }
+    ],
     "configuration": {
       "title": "Zig++",
       "properties": {

--- a/vscode/snippets/zigpp.json
+++ b/vscode/snippets/zigpp.json
@@ -1,0 +1,108 @@
+{
+  "trait": {
+    "prefix": "trait",
+    "body": [
+      "trait ${1:Name} {",
+      "    fn ${2:method}(self) ${3:void};",
+      "}"
+    ],
+    "description": "Declare a Zig++ trait."
+  },
+  "impl": {
+    "prefix": "impl",
+    "body": [
+      "impl ${1:Trait} for ${2:Type} {",
+      "    fn ${3:method}(self) ${4:void} {",
+      "        $0",
+      "    }",
+      "}"
+    ],
+    "description": "Implement a trait for a type."
+  },
+  "owned struct": {
+    "prefix": "owned",
+    "body": [
+      "owned struct ${1:Name} {",
+      "    ${2:field}: ${3:T},",
+      "",
+      "    pub fn init(${4:args}) ${1:Name} {",
+      "        return .{ .${2:field} = ${5:value} };",
+      "    }",
+      "",
+      "    pub fn deinit(self: *${1:Name}) void {",
+      "        $0",
+      "    }",
+      "}"
+    ],
+    "description": "Declare an owned struct with deinit."
+  },
+  "using": {
+    "prefix": "using",
+    "body": ["using ${1:name} = ${2:expr};"],
+    "description": "RAII binder; lowers to var + defer deinit."
+  },
+  "dyn fn": {
+    "prefix": "fndyn",
+    "body": [
+      "fn ${1:name}(${2:arg}: dyn ${3:Trait}) ${4:void} {",
+      "    $0",
+      "}"
+    ],
+    "description": "Function taking a dyn-dispatched trait object."
+  },
+  "impl trait fn": {
+    "prefix": "fnimpl",
+    "body": [
+      "fn ${1:name}(${2:arg}: impl ${3:Trait}) ${4:void} {",
+      "    $0",
+      "}"
+    ],
+    "description": "Function taking a static-dispatched trait parameter."
+  },
+  "derive": {
+    "prefix": "derive",
+    "body": ["derive(.{ ${1|Hash,Eq,Debug,Json,Ord,Default,Clone|}$0 });"],
+    "description": "Append a derive(...) clause to a struct decl."
+  },
+  "requires": {
+    "prefix": "requires",
+    "body": ["requires(${1:cond})"],
+    "description": "Function pre-condition (runtime checked in safe modes)."
+  },
+  "ensures": {
+    "prefix": "ensures",
+    "body": ["ensures(${1:cond})"],
+    "description": "Function post-condition (runs on every scope exit)."
+  },
+  "effects": {
+    "prefix": "effects",
+    "body": ["effects(${1|.alloc,.noalloc,.io,.noio,.panic|}$0)"],
+    "description": "Effect annotation (sema-linted)."
+  },
+  "extern interface": {
+    "prefix": "externi",
+    "body": [
+      "extern interface ${1:Name} {",
+      "    fn ${2:method}(self, ${3:args}) ${4:void};",
+      "}"
+    ],
+    "description": "C-ABI plugin interface (lowers to extern struct + callconv(.c))."
+  },
+  "own var": {
+    "prefix": "own",
+    "body": ["own var ${1:name} = ${2:expr};"],
+    "description": "Affine binding (subject to use-after-move sema check)."
+  },
+  "main": {
+    "prefix": "main",
+    "body": [
+      "const std = @import(\"std\");",
+      "const zpp = @import(\"zpp\");",
+      "",
+      "pub fn main() !void {",
+      "    $0",
+      "}"
+    ],
+    "description": "Standard Zig++ entry point."
+  }
+}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -179,36 +179,41 @@ function registerCommands(context: vscode.ExtensionContext): void {
 
   const explainCommand = vscode.commands.registerCommand(
     'zigpp.explain',
-    async () => {
-      // Try to pre-fill from a diagnostic at the active cursor position.
-      let initial: string | undefined;
-      const editor = vscode.window.activeTextEditor;
-      if (editor) {
-        const diags = vscode.languages.getDiagnostics(editor.document.uri);
-        const pos = editor.selection.active;
-        for (const d of diags) {
-          if (!d.range.contains(pos)) continue;
-          const code =
-            typeof d.code === 'string'
-              ? d.code
-              : typeof d.code === 'object' && d.code !== null
-                ? String((d.code as { value: unknown }).value)
-                : undefined;
-          if (code) {
-            initial = code;
-            break;
+    async (presupplied?: string) => {
+      // If invoked with a code already (e.g. from the QuickFix code action),
+      // skip the prompt entirely.
+      let arg = presupplied;
+      if (!arg) {
+        // Try to pre-fill from a diagnostic at the active cursor position.
+        let initial: string | undefined;
+        const editor = vscode.window.activeTextEditor;
+        if (editor) {
+          const diags = vscode.languages.getDiagnostics(editor.document.uri);
+          const pos = editor.selection.active;
+          for (const d of diags) {
+            if (!d.range.contains(pos)) continue;
+            const code =
+              typeof d.code === 'string'
+                ? d.code
+                : typeof d.code === 'object' && d.code !== null
+                  ? String((d.code as { value: unknown }).value)
+                  : undefined;
+            if (code) {
+              initial = code;
+              break;
+            }
           }
         }
-      }
 
-      const arg = await vscode.window.showInputBox({
-        prompt: 'Diagnostic code (e.g. Z0010)',
-        value: initial,
-        validateInput: (v) =>
-          /^[Zz]\d{4}$/.test(v.trim())
-            ? null
-            : 'Expected a Z#### code (e.g. Z0010)',
-      });
+        arg = await vscode.window.showInputBox({
+          prompt: 'Diagnostic code (e.g. Z0010)',
+          value: initial,
+          validateInput: (v) =>
+            /^[Zz]\d{4}$/.test(v.trim())
+              ? null
+              : 'Expected a Z#### code (e.g. Z0010)',
+        });
+      }
       if (!arg) return;
 
       const channel = getOutputChannel();
@@ -234,10 +239,58 @@ function registerCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(runCommand, lowerCommand, explainCommand);
 }
 
+/**
+ * Code action: when the cursor is on a Zig++ diagnostic with a Z####
+ * code, offer "Zig++: Explain Z####" as a quick-fix that runs the
+ * existing zigpp.explain command.
+ */
+class ExplainCodeActionProvider implements vscode.CodeActionProvider {
+  public static readonly providedKinds = [vscode.CodeActionKind.QuickFix];
+
+  public provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range | vscode.Selection,
+    context: vscode.CodeActionContext
+  ): vscode.CodeAction[] {
+    const actions: vscode.CodeAction[] = [];
+    for (const d of context.diagnostics) {
+      const code =
+        typeof d.code === 'string'
+          ? d.code
+          : typeof d.code === 'object' && d.code !== null
+            ? String((d.code as { value: unknown }).value)
+            : undefined;
+      if (!code || !/^Z\d{4}$/i.test(code)) continue;
+      const action = new vscode.CodeAction(
+        `Zig++: Explain ${code}`,
+        vscode.CodeActionKind.QuickFix
+      );
+      action.command = {
+        title: `Zig++: Explain ${code}`,
+        command: 'zigpp.explain',
+        arguments: [code],
+      };
+      action.diagnostics = [d];
+      actions.push(action);
+    }
+    // Suppress unused-parameter warning in strict mode.
+    void document;
+    void range;
+    return actions;
+  }
+}
+
 export async function activate(
   context: vscode.ExtensionContext
 ): Promise<void> {
   registerCommands(context);
+  context.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider(
+      { scheme: 'file', language: 'zigpp' },
+      new ExplainCodeActionProvider(),
+      { providedCodeActionKinds: ExplainCodeActionProvider.providedKinds }
+    )
+  );
   await startLanguageClient(context);
 }
 


### PR DESCRIPTION
Closes #27.

## Summary

- 13 snippets for every Zig++ extension construct (`trait`, `impl`, `owned struct`, `using`, `dyn`, `derive`, etc.).
- LSP hover now appends a `See: docs/diagnostics#z####` link.
- Quick-fix code action: `Zig++: Explain Z####` on any diagnostic.
- `zigpp.explain` command accepts a pre-supplied code so the action runs without prompting.

## Test plan

- [x] `npm run compile` clean (strict tsc)
- [x] `zig build` clean
- [x] LSP hover smoke test (Python client) returns the new docs link
- [ ] Manual: open a `.zpp` file in VS Code, see snippets in autocomplete, hover an error and see the lightbulb

## Doctrine

No language change; pure tooling polish.