### PR TITLE
feat(async): real concurrent TaskGroup with JoinHandle(T)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -151,7 +151,7 @@ exe.root_module.addImport("zpp", zpp_dep.module("zpp"));
 ```
 
 ランタイムは `Dyn`、`Owned`、`ArenaScope`、`contract.requires`、
-`derive.Hash/Eq/Debug/Json`、async の `TaskGroup` (scaffold) を公開しています。
+`derive.Hash/Eq/Debug/Json`、`std.Thread` ベースの並行 `TaskGroup` と型付き `JoinHandle(T)` を公開しています。
 コンパイラフロントエンドも `zpp_compiler` として import 可能で、lowering
 パイプラインをプログラムに組み込めます。
 

--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ exe.root_module.addImport("zpp", zpp_dep.module("zpp"));
 ```
 
 The runtime exposes `Dyn`, `Owned`, `ArenaScope`, `contract.requires`,
-`derive.Hash/Eq/Debug/Json`, and the async `TaskGroup` scaffold. The
-compiler frontend is also importable as `zpp_compiler` if you need to
-embed the lowering pipeline programmatically.
+`derive.Hash/Eq/Debug/Json`, and a `std.Thread`-backed concurrent
+`TaskGroup` with typed `JoinHandle(T)`. The compiler frontend is also
+importable as `zpp_compiler` if you need to embed the lowering pipeline
+programmatically.
 
 ## Editor support
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -112,9 +112,11 @@ calls anything that allocates).
 {{#include ./output/async_group.txt}}
 ```
 
-`zpp.async_mod.TaskGroup` is the MVP serial executor — `spawn`
-schedules, `join` runs to completion. Every primitive is explicit;
-there is no implicit await.
+`zpp.async_mod.TaskGroup` is a real concurrent executor: each
+`spawn` launches an OS thread immediately and returns a typed
+`*JoinHandle(T)`; `join` waits on every worker and propagates the
+first error after setting the group's `CancellationToken`. Every
+primitive is explicit; there is no implicit await.
 
 ## event_bus.zpp — integration showcase
 

--- a/docs/src/v0.2-plan.md
+++ b/docs/src/v0.2-plan.md
@@ -18,22 +18,32 @@ control flow / destructor / dispatch / cost".
 
 ---
 
-## 🟢 Real async runtime (was: scaffold)
+## ✅ Real async runtime
 
-Today `zpp.async_mod.TaskGroup` is a serial executor: `spawn`
-allocates a closure, queues it, and `join` runs them in order.
+`zpp.async_mod.TaskGroup` is now a real concurrent executor.
 
-Plan:
-- Track Zig 0.16's `std.Io` interface and rebuild `TaskGroup` on
-  top of it. The MVP serial executor stays as a fallback for
-  non-Io targets.
-- Introduce `zpp.async_mod.JoinHandle(T)` so `spawn` can return a
-  result instead of being void-only.
-- Keep `spawn`/`join`/`cancel` as the only primitives. No implicit
-  `await` keyword — every join is a function call.
+Done:
+- `spawn` launches each task on its own OS thread via
+  `std.Thread.spawn` and returns a typed `*JoinHandle(T)` that
+  publishes the task's result (or error) over a release/acquire
+  edge on an atomic state tag.
+- `TaskGroup.join()` waits on every worker; on first failure it
+  sets the group's `CancellationToken` so cooperative tasks can
+  short-circuit, then returns the first error after every thread
+  has been reaped.
+- `Task` is preserved as `JoinHandle(void)` so callers that
+  ignore the spawn result keep compiling unchanged
+  (`examples/async_group.zpp` runs end-to-end under `zig build e2e`).
+- `tests/behavior/async.zig` covers a 100-task stress matrix
+  (concurrent completion, distinct payloads, typed results, single-
+  failure error propagation).
 
-Risk: stdlib churn. We pin Zig versions in CI, so a major API
-break in 0.16 means we wait for the dust to settle before merging.
+Still TODO (tracking, not blocking 0.2):
+- Migrate the implementation to Zig 0.17+'s `std.Io` interface
+  (`Io.async` / `Io.cancel`) once the API stabilises. The
+  `JoinHandle(T)` surface is the seam that lets the swap happen
+  without churning callers.
+- `.noasync` effect interaction with the new I/O model (Phase 7).
 
 ---
 

--- a/lib/async.zig
+++ b/lib/async.zig
@@ -1,8 +1,17 @@
-//! Structured concurrency scaffolding.
+//! Structured concurrency built on `std.Thread`.
 //!
-//! MVP serial executor: `spawn` records a closure, `join` runs them in
-//! submission order on the calling thread. Will be replaced by Zig 0.17+ I/O
-//! interface (Io.async / Io.cancel) once stable.
+//! `TaskGroup` owns a set of concurrent worker threads. `spawn` launches a
+//! task immediately on its own OS thread and returns a typed
+//! `*JoinHandle(T)`; the caller can `join()` that handle to retrieve the
+//! result, or ignore it and rely on `TaskGroup.join()` to wait on every
+//! task. If any task fails, the group's `CancellationToken` is set so
+//! cooperative tasks can short-circuit, and the first error is returned
+//! after every task has been joined.
+//!
+//! When Zig 0.17+ `Io.async` / `Io.cancel` stabilise we will swap the
+//! `std.Thread` implementation for cooperative tasks behind the same
+//! surface — `JoinHandle(T)` is the public seam that lets that happen
+//! without churning callers.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
@@ -29,32 +38,91 @@ pub const CancellationToken = struct {
 
 pub const TaskState = enum(u8) { pending, running, done, failed, cancelled };
 
-const TaskRunFn = *const fn (*Task) anyerror!void;
+/// Typed handle to a single spawned task. Callers can:
+///   * poll `isDone()` without blocking,
+///   * block with `wait()` (no result), or
+///   * block + retrieve the typed result with `join()`.
+///
+/// Lifetime: the handle is owned by the `TaskGroup` that produced it.
+/// `TaskGroup.deinit()` joins and destroys every still-live handle.
+pub fn JoinHandle(comptime T: type) type {
+    return struct {
+        const Self = @This();
+        pub const Result = T;
 
-pub const Task = struct {
-    allocator: Allocator,
-    state: TaskState = .pending,
-    err: ?anyerror = null,
-    run_fn: TaskRunFn,
-    closure: *anyopaque,
-    closure_drop: *const fn (Allocator, *anyopaque) void,
+        allocator: Allocator,
+        thread: std.Thread,
+        // Written by the worker before the .release store of `state`, read
+        // by the joiner after the matching .acquire load (or after
+        // `thread.join()` returns). No locking required.
+        result: ResultSlot = if (T == void) {} else undefined,
+        err: ?anyerror = null,
+        state: std.atomic.Value(u8) = .{ .raw = @intFromEnum(TaskState.pending) },
+        joined: bool = false,
+        closure: *anyopaque,
+        closure_drop: *const fn (Allocator, *anyopaque) void,
 
-    pub fn isDone(self: *const Task) bool {
-        return switch (self.state) {
-            .done, .failed, .cancelled => true,
-            else => false,
-        };
-    }
+        const ResultSlot = if (T == void) void else T;
 
-    pub fn destroy(self: *Task) void {
-        self.closure_drop(self.allocator, self.closure);
-        self.allocator.destroy(self);
-    }
+        pub fn currentState(self: *const Self) TaskState {
+            return @enumFromInt(self.state.load(.acquire));
+        }
+
+        pub fn isDone(self: *const Self) bool {
+            return switch (self.currentState()) {
+                .done, .failed, .cancelled => true,
+                else => false,
+            };
+        }
+
+        /// Block until the task finishes. Idempotent.
+        pub fn wait(self: *Self) void {
+            if (self.joined) return;
+            self.thread.join();
+            self.joined = true;
+        }
+
+        /// Block until the task finishes and return its typed result.
+        /// Errors raised inside the task are propagated. Calling `join`
+        /// twice returns the same outcome.
+        pub fn join(self: *Self) !T {
+            self.wait();
+            return switch (self.currentState()) {
+                .done => if (T == void) {} else self.result,
+                .failed => self.err orelse error.TaskFailed,
+                .cancelled => error.Cancelled,
+                .pending, .running => unreachable,
+            };
+        }
+
+        /// Tear down the handle. Joins the worker first so the closure
+        /// storage is never freed under a live thread.
+        pub fn destroy(self: *Self) void {
+            self.wait();
+            self.closure_drop(self.allocator, self.closure);
+            self.allocator.destroy(self);
+        }
+    };
+}
+
+/// Backwards-compat alias: a `Task` is a `JoinHandle(void)`. Code that
+/// discards the spawn result (`_ = try group.spawn(f, args)`) keeps
+/// compiling for `void`-returning `f`.
+pub const Task = JoinHandle(void);
+
+/// Type-erased entry stored in `TaskGroup.tasks`. Each entry remembers
+/// just enough to wait on, query, and destroy its concrete
+/// `*JoinHandle(T)` without the group caring what `T` is.
+const TrackedTask = struct {
+    handle: *anyopaque,
+    wait_fn: *const fn (*anyopaque) void,
+    err_fn: *const fn (*anyopaque) ?anyerror,
+    destroy_fn: *const fn (*anyopaque) void,
 };
 
 pub const TaskGroup = struct {
     allocator: Allocator,
-    tasks: std.ArrayList(*Task),
+    tasks: std.ArrayList(TrackedTask),
     cancel_token: CancellationToken = .{},
     joined: bool = false,
 
@@ -65,37 +133,95 @@ pub const TaskGroup = struct {
         };
     }
 
-    pub fn spawn(self: *TaskGroup, comptime f: anytype, args: anytype) !*Task {
+    pub fn spawn(self: *TaskGroup, comptime f: anytype, args: anytype) !*JoinHandle(ReturnPayload(@TypeOf(f))) {
+        if (self.joined) return error.GroupAlreadyJoined;
+
+        const F = @TypeOf(f);
+        const Payload = ReturnPayload(F);
+        const Handle = JoinHandle(Payload);
         const Args = @TypeOf(args);
+        const ret_is_error_union = @typeInfo(@typeInfo(F).@"fn".return_type orelse void) == .error_union;
+
         const Closure = struct {
             args: Args,
-            fn run(task: *Task) anyerror!void {
-                const c: *@This() = @ptrCast(@alignCast(task.closure));
-                const RetT = @typeInfo(@TypeOf(f)).@"fn".return_type orelse void;
-                if (@typeInfo(RetT) == .error_union) {
-                    _ = try @call(.auto, f, c.args);
+            handle: *Handle,
+
+            fn entry(c: *@This()) void {
+                c.handle.state.store(@intFromEnum(TaskState.running), .release);
+                if (ret_is_error_union) {
+                    if (@call(.auto, f, c.args)) |val| {
+                        if (Payload != void) c.handle.result = val;
+                        c.handle.state.store(@intFromEnum(TaskState.done), .release);
+                    } else |e| {
+                        c.handle.err = e;
+                        c.handle.state.store(@intFromEnum(TaskState.failed), .release);
+                    }
                 } else {
-                    _ = @call(.auto, f, c.args);
+                    const v = @call(.auto, f, c.args);
+                    if (Payload != void) c.handle.result = v;
+                    c.handle.state.store(@intFromEnum(TaskState.done), .release);
                 }
             }
-            fn drop(a: Allocator, p: *anyopaque) void {
+
+            fn drop(allocator: Allocator, p: *anyopaque) void {
                 const c: *@This() = @ptrCast(@alignCast(p));
-                a.destroy(c);
+                allocator.destroy(c);
             }
         };
 
-        const closure = try self.allocator.create(Closure);
-        closure.* = .{ .args = args };
+        // Erased vtable methods bound to this concrete `Handle` type.
+        const Erased = struct {
+            fn waitFn(p: *anyopaque) void {
+                const h: *Handle = @ptrCast(@alignCast(p));
+                h.wait();
+            }
+            fn errFn(p: *anyopaque) ?anyerror {
+                const h: *Handle = @ptrCast(@alignCast(p));
+                return switch (h.currentState()) {
+                    .failed => h.err orelse error.TaskFailed,
+                    .cancelled => error.Cancelled,
+                    else => null,
+                };
+            }
+            fn destroyFn(p: *anyopaque) void {
+                const h: *Handle = @ptrCast(@alignCast(p));
+                h.destroy();
+            }
+        };
 
-        const task = try self.allocator.create(Task);
-        task.* = .{
+        const handle = try self.allocator.create(Handle);
+        errdefer self.allocator.destroy(handle);
+
+        const closure = try self.allocator.create(Closure);
+        errdefer self.allocator.destroy(closure);
+
+        // Initialize handle/closure BEFORE spawning the thread: the worker
+        // touches `state`, `result`, `err`, and `closure.handle`, so they
+        // must be valid when `std.Thread.spawn` returns. `handle.thread`
+        // is left undefined here and filled in below; the worker never
+        // reads it.
+        handle.* = .{
             .allocator = self.allocator,
-            .run_fn = Closure.run,
+            .thread = undefined,
             .closure = @ptrCast(closure),
             .closure_drop = Closure.drop,
         };
-        try self.tasks.append(self.allocator, task);
-        return task;
+        closure.* = .{ .args = args, .handle = handle };
+
+        // Reserve the slot before spawning so that the post-spawn append
+        // cannot fail and leak a live thread.
+        try self.tasks.ensureUnusedCapacity(self.allocator, 1);
+
+        const thread = try std.Thread.spawn(.{}, Closure.entry, .{closure});
+        handle.thread = thread;
+
+        self.tasks.appendAssumeCapacity(.{
+            .handle = @ptrCast(handle),
+            .wait_fn = Erased.waitFn,
+            .err_fn = Erased.errFn,
+            .destroy_fn = Erased.destroyFn,
+        });
+        return handle;
     }
 
     pub fn cancel(self: *TaskGroup) void {
@@ -106,57 +232,84 @@ pub const TaskGroup = struct {
         return &self.cancel_token;
     }
 
-    /// Run all spawned tasks to completion in submission order. Returns the
-    /// first error encountered; remaining tasks still run so their resources
-    /// can be released.
+    /// Wait for every spawned task to finish. If any task fails, the
+    /// group's `CancellationToken` is set so cooperative tasks can
+    /// short-circuit, and the first error is returned after every task
+    /// has been joined (so all worker threads are reaped before return).
     pub fn join(self: *TaskGroup) !void {
         if (self.joined) return;
         self.joined = true;
+
         var first_err: ?anyerror = null;
-        for (self.tasks.items) |task| {
-            if (self.cancel_token.isCancelled()) {
-                task.state = .cancelled;
-                continue;
-            }
-            task.state = .running;
-            if (task.run_fn(task)) |_| {
-                task.state = .done;
-            } else |e| {
-                task.state = .failed;
-                task.err = e;
-                if (first_err == null) first_err = e;
+        for (self.tasks.items) |t| {
+            t.wait_fn(t.handle);
+            if (first_err == null) {
+                if (t.err_fn(t.handle)) |e| {
+                    first_err = e;
+                    self.cancel_token.cancel();
+                }
             }
         }
         if (first_err) |e| return e;
     }
 
     pub fn deinit(self: *TaskGroup) void {
-        for (self.tasks.items) |task| task.destroy();
+        for (self.tasks.items) |t| t.destroy_fn(t.handle);
         self.tasks.deinit(self.allocator);
         self.* = undefined;
     }
 };
 
-/// Sleep stub: real implementation will route through `std.Io` once 0.17 lands.
+/// Strip an optional error union, returning the payload type. For
+/// non-error-union return types this is the type itself.
+fn ReturnPayload(comptime F: type) type {
+    const fn_info = @typeInfo(F).@"fn";
+    const ret = fn_info.return_type orelse void;
+    const ri = @typeInfo(ret);
+    return if (ri == .error_union) ri.error_union.payload else ret;
+}
+
+/// Sleep stub: real implementation will route through `std.Io` once 0.17
+/// lands.
 pub fn yieldNow() void {
     std.Thread.yield() catch {};
 }
 
-const TestCtx = struct { counter: *u32, bump_by: u32 };
+// -- tests -------------------------------------------------------------
+
+const TestCtx = struct {
+    counter: *std.atomic.Value(u32),
+    bump_by: u32,
+};
 
 fn bumpFn(ctx: *TestCtx) void {
-    ctx.counter.* += ctx.bump_by;
+    _ = ctx.counter.fetchAdd(ctx.bump_by, .monotonic);
 }
 
 fn boomFn() error{Boom}!void {
     return error.Boom;
 }
 
-test "TaskGroup runs spawned tasks in order on join" {
+fn squareFn(x: u32) u32 {
+    return x *% x;
+}
+
+fn cancellableFn(ctx: *CancellableCtx) error{Cancelled}!u32 {
+    var spins: u32 = 0;
+    while (spins < 1_000_000) : (spins += 1) {
+        try ctx.tok.throwIfCancelled();
+        std.Thread.yield() catch {};
+    }
+    return 0;
+}
+
+const CancellableCtx = struct { tok: *CancellationToken };
+
+test "TaskGroup runs spawned tasks concurrently and waits on join" {
     var group = TaskGroup.init(std.testing.allocator);
     defer group.deinit();
 
-    var counter: u32 = 0;
+    var counter = std.atomic.Value(u32).init(0);
     var ctx_a = TestCtx{ .counter = &counter, .bump_by = 1 };
     var ctx_b = TestCtx{ .counter = &counter, .bump_by = 10 };
     var ctx_c = TestCtx{ .counter = &counter, .bump_by = 100 };
@@ -166,7 +319,7 @@ test "TaskGroup runs spawned tasks in order on join" {
     _ = try group.spawn(bumpFn, .{&ctx_c});
 
     try group.join();
-    try std.testing.expectEqual(@as(u32, 111), counter);
+    try std.testing.expectEqual(@as(u32, 111), counter.load(.acquire));
 }
 
 test "TaskGroup propagates first error" {
@@ -174,6 +327,25 @@ test "TaskGroup propagates first error" {
     defer group.deinit();
     _ = try group.spawn(boomFn, .{});
     try std.testing.expectError(error.Boom, group.join());
+}
+
+test "JoinHandle(T).join returns the typed result" {
+    var group = TaskGroup.init(std.testing.allocator);
+    defer group.deinit();
+    const h = try group.spawn(squareFn, .{@as(u32, 7)});
+    try std.testing.expectEqual(@as(u32, 49), try h.join());
+    // group.join() after individual h.join() must be a no-op: the
+    // erased wait_fn delegates to JoinHandle.wait() which is idempotent.
+    try group.join();
+}
+
+test "TaskGroup.cancel signals cooperative tasks via the shared token" {
+    var group = TaskGroup.init(std.testing.allocator);
+    defer group.deinit();
+    var ctx = CancellableCtx{ .tok = group.token() };
+    _ = try group.spawn(cancellableFn, .{&ctx});
+    group.cancel();
+    try std.testing.expectError(error.Cancelled, group.join());
 }
 
 test "CancellationToken is observable across spawn" {

--- a/tests/behavior/async.zig
+++ b/tests/behavior/async.zig
@@ -1,0 +1,97 @@
+const std = @import("std");
+const zpp = @import("zpp");
+
+const async_mod = zpp.async_mod;
+
+fn incFn(slot: *std.atomic.Value(u32)) void {
+    _ = slot.fetchAdd(1, .monotonic);
+}
+
+const SumCtx = struct {
+    total: *std.atomic.Value(u64),
+    delta: u64,
+};
+
+fn addFn(ctx: *SumCtx) void {
+    _ = ctx.total.fetchAdd(ctx.delta, .monotonic);
+}
+
+fn squareFn(x: u32) u32 {
+    return x *% x;
+}
+
+fn failingFn(id: u32) error{Boom}!void {
+    if (id == 42) return error.Boom;
+}
+
+const TASK_COUNT: u32 = 100;
+
+test "TaskGroup stress: 100 concurrent tasks all run to completion" {
+    var group = async_mod.TaskGroup.init(std.testing.allocator);
+    defer group.deinit();
+
+    var counter = std.atomic.Value(u32).init(0);
+    var i: u32 = 0;
+    while (i < TASK_COUNT) : (i += 1) {
+        _ = try group.spawn(incFn, .{&counter});
+    }
+
+    try group.join();
+    try std.testing.expectEqual(TASK_COUNT, counter.load(.acquire));
+}
+
+test "TaskGroup stress: 100 tasks with distinct payloads sum correctly" {
+    var group = async_mod.TaskGroup.init(std.testing.allocator);
+    defer group.deinit();
+
+    var total = std.atomic.Value(u64).init(0);
+
+    // Stack-allocated context array shared across spawns. Each entry
+    // carries a unique delta so a successful concurrent run produces a
+    // deterministic sum (sum 1..=100 = 5050).
+    var contexts: [TASK_COUNT]SumCtx = undefined;
+    var i: u32 = 0;
+    while (i < TASK_COUNT) : (i += 1) {
+        contexts[i] = .{ .total = &total, .delta = i + 1 };
+        _ = try group.spawn(addFn, .{&contexts[i]});
+    }
+
+    try group.join();
+    try std.testing.expectEqual(@as(u64, 5050), total.load(.acquire));
+}
+
+test "TaskGroup stress: typed JoinHandle results across 100 tasks" {
+    var group = async_mod.TaskGroup.init(std.testing.allocator);
+    defer group.deinit();
+
+    var handles: [TASK_COUNT]*async_mod.JoinHandle(u32) = undefined;
+    var i: u32 = 0;
+    while (i < TASK_COUNT) : (i += 1) {
+        handles[i] = try group.spawn(squareFn, .{i});
+    }
+
+    // Drain results in submission order; concurrent execution is fine
+    // because each handle has its own slot.
+    var seen: u64 = 0;
+    i = 0;
+    while (i < TASK_COUNT) : (i += 1) {
+        const got = try handles[i].join();
+        try std.testing.expectEqual(i *% i, got);
+        seen += got;
+    }
+    try group.join();
+
+    // Sanity: sum_{i=0..99} i*i = 99*100*199/6 = 328350.
+    try std.testing.expectEqual(@as(u64, 328350), seen);
+}
+
+test "TaskGroup stress: one failure among 100 propagates as first error" {
+    var group = async_mod.TaskGroup.init(std.testing.allocator);
+    defer group.deinit();
+
+    var i: u32 = 0;
+    while (i < TASK_COUNT) : (i += 1) {
+        _ = try group.spawn(failingFn, .{i});
+    }
+    try std.testing.expectError(error.Boom, group.join());
+}


### PR DESCRIPTION
## Summary
- Replaces the serial MVP executor in `lib/async.zig` with a real
  concurrent runtime backed by `std.Thread`. Every `spawn` launches an
  OS thread immediately and returns a typed `*JoinHandle(T)`.
- `TaskGroup.join()` waits for every worker; on first failure it sets
  the group's `CancellationToken` so cooperative tasks can short-circuit
  before returning the first error.
- `Task` is preserved as `JoinHandle(void)` so `examples/async_group.zpp`
  (and any other discard-the-handle caller) compiles unchanged. Closes #25.

## What's new
- `JoinHandle(T)` — `isDone()`, `wait()` (idempotent), `join() !T`,
  `destroy()`. Result/error publication uses a release/acquire edge on
  the `state` atomic; the worker writes `result`/`err` before the
  `.release` store and the joiner reads them after `.acquire` /
  `Thread.join()`.
- `TaskGroup` now stores type-erased entries (`TrackedTask`) so it can
  hold `JoinHandle(T)` values for differing `T` and still wait/destroy
  uniformly.
- `examples/async_group.zpp` is unchanged and runs end-to-end under
  `zig build e2e`.

## Tests
Inline (`lib/async.zig`):
- concurrent completion via atomic counter (replaces the old "in order"
  assertion that no longer holds under real concurrency)
- first-error propagation
- `JoinHandle(T).join` returns a typed result; subsequent `group.join()`
  is a no-op
- `TaskGroup.cancel()` is observable inside cooperative workers

Stress (`tests/behavior/async.zig`, 100 tasks each):
- 100 concurrent increments → counter == 100
- 100 distinct deltas → deterministic sum (5050)
- 100 typed `JoinHandle(u32)` results → squares match, sum == 328350
- 100 tasks with one failing → first error propagates

## Test plan
- [x] `zig build test` (silent on success)
- [x] `zig build all` green (test + check + examples + e2e + bench)
- [x] `examples/async_group.zpp` unchanged; runs successfully under e2e
- [x] Stress tests cover ≥100 tasks across the four scenarios above

🤖 Generated with [Claude Code](https://claude.com/claude-code)