### PR TITLE
feat(sema): Z0040 impl missing trait method

### DIFF
--- a/compiler/diagnostics.zig
+++ b/compiler/diagnostics.zig
@@ -41,6 +41,7 @@ pub const Code = enum {
     z0011_using_type_lacks_deinit,
     z0020_use_after_move,
     z0030_effect_violation,
+    z0040_impl_missing_method,
     z0100_unexpected_token,
     z0101_expected_identifier,
     z0102_expected_token,
@@ -56,6 +57,7 @@ pub const Code = enum {
             .z0011_using_type_lacks_deinit => "Z0011",
             .z0020_use_after_move => "Z0020",
             .z0030_effect_violation => "Z0030",
+            .z0040_impl_missing_method => "Z0040",
             .z0100_unexpected_token => "Z0100",
             .z0101_expected_identifier => "Z0101",
             .z0102_expected_token => "Z0102",
@@ -77,6 +79,7 @@ pub fn hint(code: Code) ?[]const u8 {
         .z0011_using_type_lacks_deinit => "give the type a `deinit` method, or drop the `using` binding so the compiler does not try to auto-release it.",
         .z0020_use_after_move => "the value was consumed by `move`. Rebind it (`own var x = ...`) or restructure the code to keep a single owner.",
         .z0030_effect_violation => "the function declared an effect it then violated. Remove the `effects(...)` annotation or eliminate the disallowed operation (allocation, IO, etc.).",
+        .z0040_impl_missing_method => "every method declared on the trait must be implemented. Add the listed missing methods, or drop the impl block if you do not intend to satisfy the trait.",
         .z0100_unexpected_token => "remove or replace the highlighted token. The parser was in the middle of a declaration or expression and could not continue.",
         .z0101_expected_identifier => "supply a name here, e.g. `fn name(...)`, `struct Name { ... }`, or `const name = ...`.",
         .z0102_expected_token => "insert the expected token. Most often a missing `;`, `,`, `)`, or `}` in the surrounding scope.",
@@ -179,6 +182,24 @@ pub fn explain(code: Code) []const u8 {
         \\
         \\Fix: drop the `effects(.noalloc)` annotation, or eliminate the
         \\allocation (use a fixed buffer / arena owned by the caller).
+        ,
+        .z0040_impl_missing_method =>
+        \\Z0040: impl is missing trait method(s)
+        \\
+        \\An `impl Trait for Type { ... }` block must implement every method
+        \\declared on `trait Trait { ... }`. Sema cross-checks the two and
+        \\lists any methods that are required by the trait but not present
+        \\in the impl.
+        \\
+        \\Triggers:
+        \\    trait Greeter { fn greet(self) void; fn farewell(self) void; }
+        \\    impl Greeter for Friendly {
+        \\        fn greet(self) void {}
+        \\        // farewell is missing
+        \\    }
+        \\
+        \\Fix: add the missing method(s), or remove the impl block if Type
+        \\does not need to satisfy Greeter.
         ,
         .z0100_unexpected_token =>
         \\Z0100: unexpected token

--- a/compiler/sema.zig
+++ b/compiler/sema.zig
@@ -7,11 +7,15 @@ pub const SemaResult = struct {
     allocator: std.mem.Allocator,
     /// Set of trait names declared in the file.
     traits: std.StringHashMap(void),
+    /// Method-name lists per trait so impl checks can cross-verify.
+    /// Slices reference the original AST arena and are not freed here.
+    trait_methods: std.StringHashMap([]const ast.TraitMethod),
     /// Map of owned-struct names → whether they have a deinit method.
     owned_structs: std.StringHashMap(bool),
 
     pub fn deinit(self: *SemaResult) void {
         self.traits.deinit();
+        self.trait_methods.deinit();
         self.owned_structs.deinit();
     }
 };
@@ -28,6 +32,7 @@ pub const Sema = struct {
         var result: SemaResult = .{
             .allocator = self.allocator,
             .traits = std.StringHashMap(void).init(self.allocator),
+            .trait_methods = std.StringHashMap([]const ast.TraitMethod).init(self.allocator),
             .owned_structs = std.StringHashMap(bool).init(self.allocator),
         };
         errdefer result.deinit();
@@ -45,8 +50,14 @@ pub const Sema = struct {
         _ = self;
         for (file.decls) |d| {
             switch (d) {
-                .trait => |t| try r.traits.put(t.name, {}),
-                .extern_interface => |e| try r.traits.put(e.name, {}),
+                .trait => |t| {
+                    try r.traits.put(t.name, {});
+                    try r.trait_methods.put(t.name, t.methods);
+                },
+                .extern_interface => |e| {
+                    try r.traits.put(e.name, {});
+                    try r.trait_methods.put(e.name, e.methods);
+                },
                 .owned_struct => |o| {
                     var has_deinit = false;
                     for (o.fns) |f| {
@@ -100,6 +111,33 @@ pub const Sema = struct {
                             i.span,
                             "impl references unknown trait '{s}'",
                             .{i.trait_name},
+                        );
+                        continue;
+                    }
+                    // Cross-check that every method declared by the trait is
+                    // present in this impl. Missing methods → Z0040.
+                    const methods = r.trait_methods.get(i.trait_name) orelse continue;
+                    var missing: std.ArrayList([]const u8) = .{};
+                    defer missing.deinit(self.allocator);
+                    for (methods) |m| {
+                        var found = false;
+                        for (i.fns) |fd| {
+                            if (std.mem.eql(u8, fd.sig.name, m.name)) {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (!found) try missing.append(self.allocator, m.name);
+                    }
+                    if (missing.items.len > 0) {
+                        const list = try joinNames(self.allocator, missing.items);
+                        defer self.allocator.free(list);
+                        try self.diags.emit(
+                            .err,
+                            .z0040_impl_missing_method,
+                            i.span,
+                            "impl {s} for {s} is missing method(s): {s}",
+                            .{ i.trait_name, i.target_type, list },
                         );
                     }
                 },
@@ -288,6 +326,19 @@ pub const Sema = struct {
 /// Heuristic: does `text` look like an allocator-using call? We check for
 /// identifiers containing "alloc"/"init"/"create" near a token that resembles
 /// an allocator argument. For MVP we keep this loose.
+/// Join name slices into a single comma-separated string. Caller frees.
+fn joinNames(allocator: std.mem.Allocator, names: []const []const u8) ![]u8 {
+    var out: std.ArrayList(u8) = .{};
+    defer out.deinit(allocator);
+    for (names, 0..) |n, i| {
+        if (i > 0) try out.appendSlice(allocator, ", ");
+        try out.append(allocator, '\'');
+        try out.appendSlice(allocator, n);
+        try out.append(allocator, '\'');
+    }
+    return out.toOwnedSlice(allocator);
+}
+
 fn callsAllocator(text: []const u8) bool {
     if (containsToken(text, "alloc")) return true;
     if (containsToken(text, "create")) return true;

--- a/tests/diagnostics/diags.zig
+++ b/tests/diagnostics/diags.zig
@@ -56,3 +56,36 @@ test "Z0030: noalloc effect violated by allocator call" {
     defer result.diags.deinit();
     try std.testing.expect(hasCode(&result.diags, "Z0030"));
 }
+
+test "Z0040: impl missing trait method" {
+    const a = std.testing.allocator;
+    const src =
+        \\trait Greeter {
+        \\    fn greet(self) void;
+        \\    fn farewell(self) void;
+        \\}
+        \\const Friendly = struct { name: []const u8 };
+        \\impl Greeter for Friendly {
+        \\    fn greet(self) void { _ = self; }
+        \\}
+    ;
+    var result = try analyze(a, src);
+    defer result.diags.deinit();
+    try std.testing.expect(hasCode(&result.diags, "Z0040"));
+}
+
+test "Z0040: complete impl produces no diagnostic" {
+    const a = std.testing.allocator;
+    const src =
+        \\trait Greeter {
+        \\    fn greet(self) void;
+        \\}
+        \\const Friendly = struct { name: []const u8 };
+        \\impl Greeter for Friendly {
+        \\    fn greet(self) void { _ = self; }
+        \\}
+    ;
+    var result = try analyze(a, src);
+    defer result.diags.deinit();
+    try std.testing.expect(!hasCode(&result.diags, "Z0040"));
+}


### PR DESCRIPTION
Closes #32. Adds a new sema check that fires when an `impl Trait for X` omits methods declared by `trait Trait`.

## Test plan
- [x] zig build test (140+ tests + 2 new in tests/diagnostics)
- [x] zig build check (no example regression)
- [x] Manual repro: impl with missing method emits Z0040, complete impl is silent