### PR TITLE
feat: ?dyn Trait first-class syntax (#36)

### DIFF
--- a/compiler/ast.zig
+++ b/compiler/ast.zig
@@ -11,6 +11,8 @@ pub const ParamMode = enum {
     impl_trait,
     /// `name: dyn Trait` — lowers to fat pointer + vtable.
     dyn_trait,
+    /// `name: ?dyn Trait` — optional fat pointer; lowers to `?zpp.Dyn(...)`.
+    nullable_dyn_trait,
     /// `name: anytype`.
     any_type,
     /// `comptime name: Type`.

--- a/compiler/lower_to_zig.zig
+++ b/compiler/lower_to_zig.zig
@@ -413,6 +413,7 @@ pub const Lowerer = struct {
             .any_type => try self.writeFmt("{s}: anytype", .{p.name}),
             .impl_trait => try self.writeFmt("{s}: anytype", .{p.name}),
             .dyn_trait => try self.writeFmt("{s}: zpp.Dyn({s}_VTable)", .{ p.name, p.type_text }),
+            .nullable_dyn_trait => try self.writeFmt("{s}: ?zpp.Dyn({s}_VTable)", .{ p.name, p.type_text }),
         }
     }
 

--- a/compiler/parser.zig
+++ b/compiler/parser.zig
@@ -329,6 +329,21 @@ pub const Parser = struct {
                 .span = .{ .start = start, .end = trait_tok.span.end },
             };
         }
+        // ?dyn Trait — optional fat pointer.
+        if (self.check(.question)) {
+            // Look ahead: ? dyn Ident
+            if (self.peekAt(1).kind == .kw_dyn and self.peekAt(2).kind == .ident) {
+                _ = self.advance(); // ?
+                _ = self.advance(); // dyn
+                const trait_tok = self.advance(); // Ident
+                return .{
+                    .name = name_text,
+                    .type_text = trait_tok.slice(self.source),
+                    .mode = .nullable_dyn_trait,
+                    .span = .{ .start = start, .end = trait_tok.span.end },
+                };
+            }
+        }
         if (self.check(.kw_anytype)) {
             const t = self.advance();
             return .{

--- a/tests/compile/basic.zig
+++ b/tests/compile/basic.zig
@@ -122,6 +122,20 @@ test "derive(Compare) emits lt/le/gt/ge methods" {
     try std.testing.expect(std.mem.indexOf(u8, out, "pub fn ge(self: @This(), other: @This()) bool") != null);
 }
 
+test "?dyn Trait param lowers to ?zpp.Dyn(VTable)" {
+    const a = std.testing.allocator;
+    const src =
+        \\trait Greeter {
+        \\    fn greet(self) void;
+        \\}
+        \\fn maybeGreet(who: ?dyn Greeter) void { _ = who; }
+    ;
+    const out = try lower(a, src);
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "?zpp.Dyn(Greeter_VTable)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "who: zpp.Dyn") == null);
+}
+
 test "derive(FromStr) emits a fromStr() method" {
     const a = std.testing.allocator;
     const src =


### PR DESCRIPTION
Closes #36. `fn f(x: ?dyn Trait)` now lowers to `?zpp.Dyn(Trait_VTable)` directly.

## Test plan
- [x] zig build test (new lowering test passes)
- [x] zig build all
- [x] manual: maybeGreet(null) and maybeGreet(value) both work end-to-end