### PR TITLE
feat(tools): `zpp explain --list` shows every diagnostic code (#39)

### DIFF
--- a/compiler/diagnostics.zig
+++ b/compiler/diagnostics.zig
@@ -298,6 +298,30 @@ pub fn codeFromId(id_str: []const u8) ?Code {
     return null;
 }
 
+/// One-line summary for each diagnostic — the first line of `explain(code)`,
+/// stripped of the `Z####: ` prefix. Used by `zpp explain --list`.
+pub fn summary(code: Code) []const u8 {
+    const text = explain(code);
+    const newline = std.mem.indexOfScalar(u8, text, '\n') orelse text.len;
+    const first_line = text[0..newline];
+    // Drop the leading "Z####: " (the id is shown separately by callers).
+    if (std.mem.indexOfScalar(u8, first_line, ':')) |i| {
+        var s = first_line[i + 1 ..];
+        while (s.len > 0 and s[0] == ' ') s = s[1..];
+        return s;
+    }
+    return first_line;
+}
+
+/// Iterator-friendly list of every Code value. Used by `zpp explain --list`.
+pub const all_codes: []const Code = blk: {
+    const fields = @typeInfo(Code).@"enum".fields;
+    var arr: [fields.len]Code = undefined;
+    for (fields, 0..) |f, i| arr[i] = @enumFromInt(f.value);
+    const final = arr;
+    break :blk &final;
+};
+
 pub const Diagnostic = struct {
     severity: Severity,
     span: Span,

--- a/tools/zpp.zig
+++ b/tools/zpp.zig
@@ -145,7 +145,7 @@ fn printUsage() void {
         \\    migrate <file.zig>   suggest .zpp rewrites for a .zig file
         \\    lsp                  start LSP server on stdin/stdout
         \\    init <name>          scaffold a new Zig++ project under <name>/
-        \\    explain <Z####>      explain a diagnostic code in detail
+        \\    explain <Z####|-l>   explain a diagnostic code in detail (--list to see all)
         \\    version              print version
         \\    help [subcommand]    show this help (or details for a subcommand)
         \\
@@ -177,7 +177,7 @@ fn cmdHelp(args: [][:0]u8) !ExitCode {
         .migrate => "zpp migrate <file.zig>\n  Diff suggestions to convert defer/init/deinit patterns to Zig++.\n",
         .lsp => "zpp lsp\n  Speak LSP over stdio. Run from your editor; not for human use.\n",
         .init => "zpp init <name>\n  Scaffold a new Zig++ project under <name>/ with build.zig, build.zig.zon, src/main.zpp, and a starter README. Refuses to overwrite an existing directory.\n",
-        .explain => "zpp explain <Z####>\n  Print a long-form explanation of a diagnostic code, including a triggering example and a fix.\n",
+        .explain => "zpp explain <Z####|--list>\n  Print a long-form explanation of a diagnostic code, or `--list` to see every code with a one-line summary.\n",
         .version => "zpp version\n  Print compiler version.\n",
         .help => "zpp help [subcommand]\n  Show this message.\n",
     };
@@ -629,10 +629,13 @@ fn cmdLsp(allocator: std.mem.Allocator, args: [][:0]u8) !ExitCode {
 
 fn cmdExplain(args: [][:0]u8) !ExitCode {
     if (args.len != 1) {
-        ePrint("zpp explain: expected exactly one diagnostic code (e.g. Z0010)\n", .{});
+        ePrint("zpp explain: expected exactly one argument (Z#### code or --list)\n", .{});
         return .usage_error;
     }
     const arg = args[0];
+    if (std.mem.eql(u8, arg, "--list") or std.mem.eql(u8, arg, "-l")) {
+        return cmdExplainList();
+    }
     // Accept lower- or upper-case input; normalize to upper for lookup.
     var upper_buf: [16]u8 = undefined;
     if (arg.len > upper_buf.len) {
@@ -644,10 +647,19 @@ fn cmdExplain(args: [][:0]u8) !ExitCode {
 
     const code = compiler.diagnostics.codeFromId(upper) orelse {
         ePrint("zpp explain: unknown diagnostic code '{s}'\n", .{arg});
-        ePrint("       run `zpp help` and check sema or parser docs.\n", .{});
+        ePrint("       run `zpp explain --list` to see every code.\n", .{});
         return .user_error;
     };
     oPrint("{s}\n", .{compiler.diagnostics.explain(code)});
+    return .ok;
+}
+
+fn cmdExplainList() !ExitCode {
+    oPrint("Diagnostic codes:\n\n", .{});
+    for (compiler.diagnostics.all_codes) |code| {
+        oPrint("  {s}  {s}\n", .{ code.id(), compiler.diagnostics.summary(code) });
+    }
+    oPrint("\nRun `zpp explain Z####` for the full description, triggering example, and fix.\n", .{});
     return .ok;
 }
 
@@ -911,5 +923,15 @@ test "explain finds every code by id" {
         try std.testing.expectEqual(c, looked_up);
         // Every code has a non-empty explanation.
         try std.testing.expect(compiler.diagnostics.explain(c).len > 50);
+    }
+}
+
+test "all_codes covers every Code variant exactly once" {
+    const fields = @typeInfo(compiler.diagnostics.Code).@"enum".fields;
+    try std.testing.expectEqual(fields.len, compiler.diagnostics.all_codes.len);
+    // Each code in all_codes also has a non-empty summary().
+    for (compiler.diagnostics.all_codes) |c| {
+        try std.testing.expect(compiler.diagnostics.summary(c).len > 0);
+        try std.testing.expect(!std.mem.startsWith(u8, compiler.diagnostics.summary(c), "Z"));
     }
 }


### PR DESCRIPTION
Closes #39. `zpp explain --list` (or `-l`) prints every Z#### with its one-line summary so users can discover what is checked.

## Test plan
- [x] `zpp explain --list` and `zpp explain -l` both work
- [x] `zpp explain Z0040` still works (full text)
- [x] new test `all_codes covers every Code variant` passes
- [x] zig build all green