### PR TITLE
docs+example: pub trait cross-file visibility (#41)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -225,11 +225,13 @@ fn addE2ESteps(
     while (walker.next() catch null) |entry| {
         if (entry.kind != .file) continue;
         if (!std.mem.endsWith(u8, entry.path, ".zpp")) continue;
-        // Multi-file projects live in examples/multi_file/ and have their
+        // Multi-file projects live in examples/multi_file*/ and have their
         // own dedicated step (see addMultiFileE2E). Skip them here so we
-        // do not try to build util.zpp as a stand-alone executable.
-        if (std.mem.indexOf(u8, entry.path, "multi_file/") != null) continue;
-        if (std.mem.indexOf(u8, entry.path, "multi_file\\") != null) continue;
+        // do not try to build util.zpp / api.zpp as stand-alone executables.
+        if (std.mem.startsWith(u8, entry.path, "multi_file/")) continue;
+        if (std.mem.startsWith(u8, entry.path, "multi_file_pub/")) continue;
+        if (std.mem.startsWith(u8, entry.path, "multi_file\\")) continue;
+        if (std.mem.startsWith(u8, entry.path, "multi_file_pub\\")) continue;
 
         const src_rel = std.fs.path.join(b.allocator, &.{ "examples", entry.path }) catch continue;
         const stem = entry.basename[0 .. entry.basename.len - 4];

--- a/build.zig
+++ b/build.zig
@@ -95,7 +95,8 @@ pub fn build(b: *std.Build) void {
 
     const multi_e2e_step = b.step("multi-e2e", "Build and run examples/multi_file/ as a 2-file project");
     if (main_exe) |exe| {
-        addMultiFileE2E(b, target, optimize, zpp_module, exe, multi_e2e_step);
+        addMultiFileE2E(b, target, optimize, zpp_module, exe, multi_e2e_step, "examples/multi_file", "main", "util");
+        addMultiFileE2E(b, target, optimize, zpp_module, exe, multi_e2e_step, "examples/multi_file_pub", "main", "api");
     }
     e2e_step.dependOn(multi_e2e_step);
 
@@ -270,30 +271,33 @@ fn addMultiFileE2E(
     zpp_module: *std.Build.Module,
     zpp_exe: *std.Build.Step.Compile,
     multi_step: *std.Build.Step,
+    dir_rel: []const u8,
+    main_stem: []const u8,
+    sibling_stem: []const u8,
 ) void {
-    const main_zpp = "examples/multi_file/main.zpp";
-    const util_zpp = "examples/multi_file/util.zpp";
+    const main_zpp = b.fmt("{s}/{s}.zpp", .{ dir_rel, main_stem });
+    const sibling_zpp = b.fmt("{s}/{s}.zpp", .{ dir_rel, sibling_stem });
 
     // If either file is missing, skip silently — keeps the step a no-op
     // for branches that have not added the example yet.
     std.fs.cwd().access(main_zpp, .{}) catch return;
-    std.fs.cwd().access(util_zpp, .{}) catch return;
+    std.fs.cwd().access(sibling_zpp, .{}) catch return;
 
     const lower_main = b.addRunArtifact(zpp_exe);
     lower_main.addArg("lower");
     lower_main.addFileArg(b.path(main_zpp));
     const main_lazy = lower_main.captureStdOut();
 
-    const lower_util = b.addRunArtifact(zpp_exe);
-    lower_util.addArg("lower");
-    lower_util.addFileArg(b.path(util_zpp));
-    const util_lazy = lower_util.captureStdOut();
+    const lower_sibling = b.addRunArtifact(zpp_exe);
+    lower_sibling.addArg("lower");
+    lower_sibling.addFileArg(b.path(sibling_zpp));
+    const sibling_lazy = lower_sibling.captureStdOut();
 
     // Bundle both lowered files into one directory so main.zig can
-    // resolve `@import("util.zig")` at the same path.
+    // resolve `@import("<sibling>.zig")` at the same path.
     const wf = b.addWriteFiles();
-    const main_zig = wf.addCopyFile(main_lazy, "main.zig");
-    _ = wf.addCopyFile(util_lazy, "util.zig");
+    const main_zig = wf.addCopyFile(main_lazy, b.fmt("{s}.zig", .{main_stem}));
+    _ = wf.addCopyFile(sibling_lazy, b.fmt("{s}.zig", .{sibling_stem}));
 
     const exe_mod = b.createModule(.{
         .root_source_file = main_zig,
@@ -301,8 +305,11 @@ fn addMultiFileE2E(
         .optimize = optimize,
     });
     exe_mod.addImport("zpp", zpp_module);
+
+    // Sanitize the dir name for use as an executable name.
+    const exe_name = b.fmt("e2e-{s}", .{std.fs.path.basename(dir_rel)});
     const exe = b.addExecutable(.{
-        .name = "e2e-multi-file",
+        .name = exe_name,
         .root_module = exe_mod,
     });
     const run_exe = b.addRunArtifact(exe);

--- a/docs/src/output/multi_file_pub.txt
+++ b/docs/src/output/multi_file_pub.txt
@@ -1,0 +1,4 @@
+[main] static dispatch via the injected method
+[main] dynamic dispatch over the imported vtable instances
+>> audit | dynamic dispatch over the imported vtable instances (end)
+(cross-file pub trait + dyn dispatch)

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -385,6 +385,39 @@ zig build multi-e2e
 # main: via @import("util.zpp")
 ```
 
+## Bonus — sharing a public API across files
+
+Mark a trait or struct `pub` and another `.zpp` file can use it via
+`@import`:
+
+```zig
+// api.zpp
+pub trait Logger { fn log(self, msg: []const u8) void; }
+pub const StdoutLogger = struct { prefix: []const u8 };
+impl Logger for StdoutLogger { fn log(self, msg) void { ... } }
+```
+
+```zig
+// main.zpp
+const api = @import("api.zpp");
+
+pub fn main() !void {
+    var l = api.StdoutLogger{ .prefix = "main" };
+    l.log("hello");
+
+    // dyn dispatch over the imported vtable instance:
+    const d = zpp.Dyn(api.Logger_VTable).init(
+        api.StdoutLogger, &l, &api.Logger_impl_for_StdoutLogger,
+    );
+    d.vtable.log(d.ptr, "via dyn");
+}
+```
+
+The lowerer emits `pub const Logger_VTable`, `pub const Logger`, and
+the `pub const Logger_impl_for_StdoutLogger` vtable instance — all
+reachable from the importing module. See `examples/multi_file_pub/`
+for the full worked example, runnable via `zig build multi-e2e`.
+
 ## Bonus — explaining a diagnostic code
 
 When the compiler prints a code like `Z0020`, you can ask the CLI for

--- a/docs/src/v0.2-plan.md
+++ b/docs/src/v0.2-plan.md
@@ -158,14 +158,12 @@ based — adding a real call graph is a non-trivial refactor.
 
 ---
 
-## ✅ Multi-file projects
+## ✅ Multi-file projects (complete)
 
 `@import("other.zpp")` now lowers to `@import("other.zig")` so a
 `.zpp` file can reference a sibling `.zpp`. `zpp build` walks the
 project, lowers every `.zpp` into a mirrored `.zpp-cache/`, and
-generates a `build.zig` shim when the user has not supplied one —
-so a directory with only `.zpp` files and no `build.zig` still
-builds end-to-end via `zig build`.
+generates a `build.zig` shim when the user has not supplied one.
 
 Done:
 - Lowerer: rewrite `@import("X.zpp")` → `@import("X.zig")` in all
@@ -177,10 +175,13 @@ Done:
   `.zpp-cache/build.zig` referencing the entry point
   (`src/main.zig` or `main.zig`) when no top-level `build.zig`
   exists. End-to-end exercised by `examples/multi_file/`.
-
-Still TODO:
-- `pub trait` / `pub impl` visibility across files (today `pub`
-  is parsed but only matters for fn/struct).
+- `pub trait` / `pub impl` visibility crosses files. The lowerer
+  honors `is_pub` on `trait` (emitting both `pub const X_VTable`
+  and `pub const X = zpp.Dyn(X_VTable)`); vtable instances
+  (`pub const Foo_impl_for_Bar: Foo_VTable = .{...}`) are always
+  emitted `pub`. `examples/multi_file_pub/` showcases an importing
+  file constructing dyn pointers to vtable instances declared in
+  a sibling `.zpp` module.
 
 ---
 

--- a/examples/multi_file_pub/api.zpp
+++ b/examples/multi_file_pub/api.zpp
@@ -1,0 +1,38 @@
+/// api.zpp — public Zig++ API exposed across files.
+///
+/// Showcases that `pub trait`, `pub impl` (vtable instances are always
+/// emitted `pub`), and plain `pub const X = struct { ... }` are all
+/// reachable from a sibling `.zpp` via `@import("api.zpp")`. The
+/// lowerer emits `pub const Logger_VTable = struct {...}`,
+/// `pub const Logger = zpp.Dyn(Logger_VTable)`, and
+/// `pub const Logger_impl_for_StdoutLogger: Logger_VTable = .{...}`,
+/// so the importing file can construct dyn pointers to the impls
+/// declared here.
+
+const std = @import("std");
+const zpp = @import("zpp");
+
+pub trait Logger {
+    fn log(self, msg: []const u8) void;
+}
+
+pub const StdoutLogger = struct {
+    prefix: []const u8,
+};
+
+impl Logger for StdoutLogger {
+    fn log(self, msg: []const u8) void {
+        std.debug.print("[{s}] {s}\n", .{ self.prefix, msg });
+    }
+}
+
+pub const PrefixedLogger = struct {
+    inner_prefix: []const u8,
+    suffix: []const u8,
+};
+
+impl Logger for PrefixedLogger {
+    fn log(self, msg: []const u8) void {
+        std.debug.print(">> {s} | {s} {s}\n", .{ self.inner_prefix, msg, self.suffix });
+    }
+}

--- a/examples/multi_file_pub/main.zpp
+++ b/examples/multi_file_pub/main.zpp
@@ -1,0 +1,33 @@
+/// main.zpp — consumer of api.zpp's public surface.
+///
+/// Demonstrates calling into a sibling .zpp module via `@import`
+/// across both static (method on a pub struct) and dynamic
+/// (`zpp.Dyn(api.Logger_VTable)`) dispatch. The vtable instance
+/// `Logger_impl_for_StdoutLogger` is published from api.zpp via
+/// the same name (no namespacing because Zig++ lowering is flat
+/// per file).
+
+const std = @import("std");
+const zpp = @import("zpp");
+const api = @import("api.zpp");
+
+fn fanOut(loggers: []const zpp.Dyn(api.Logger_VTable), msg: []const u8) void {
+    for (loggers) |l| {
+        l.vtable.log(l.ptr, msg);
+    }
+}
+
+pub fn main() !void {
+    var stdout = api.StdoutLogger{ .prefix = "main" };
+    stdout.log("static dispatch via the injected method");
+
+    var prefixed = api.PrefixedLogger{ .inner_prefix = "audit", .suffix = "(end)" };
+
+    const chain = [_]zpp.Dyn(api.Logger_VTable){
+        zpp.Dyn(api.Logger_VTable).init(api.StdoutLogger, &stdout, &api.Logger_impl_for_StdoutLogger),
+        zpp.Dyn(api.Logger_VTable).init(api.PrefixedLogger, &prefixed, &api.Logger_impl_for_PrefixedLogger),
+    };
+    fanOut(&chain, "dynamic dispatch over the imported vtable instances");
+
+    std.debug.print("(cross-file pub trait + dyn dispatch)\n", .{});
+}


### PR DESCRIPTION
Closes #41. Adds a worked 2-file example showing a public Zig++ API exposed across files (`pub trait` + `pub struct` + impls) and consumed via both static and dyn dispatch.

The lowerer already supported this — this PR adds the example, generalises addMultiFileE2E for any sibling pair, marks v0.2 multi-file fully ✅, and adds a tutorial section.

## Test plan
- [x] zig build multi-e2e green
- [x] zig build all green
- [x] both single-sibling pairs (multi_file/ + multi_file_pub/) run from one step