### PR TITLE
feat(examples): cli/greet — multi-locale greeter (#44)

### DIFF
--- a/compiler/lower_to_zig.zig
+++ b/compiler/lower_to_zig.zig
@@ -354,7 +354,7 @@ pub const Lowerer = struct {
             try self.lowerParam(p);
         }
         try self.write(") ");
-        try self.write(normalizeReturn(fd.sig.return_type));
+        try self.writeRewrittenType(normalizeReturn(fd.sig.return_type));
 
         if (fd.body) |body| {
             try self.write(" {\n");

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -23,6 +23,11 @@
   - [effects_pure](./api/effects_pure.md)
   - [async_group](./api/async_group.md)
   - [event_bus](./api/event_bus.md)
+  - [multi_file/util](./api/multi_file/util.md)
+  - [multi_file/main](./api/multi_file/main.md)
+  - [multi_file_pub/api](./api/multi_file_pub/api.md)
+  - [multi_file_pub/main](./api/multi_file_pub/main.md)
+  - [cli/greet](./api/cli/greet.md)
 
 # Project
 

--- a/docs/src/api/cli/greet.md
+++ b/docs/src/api/cli/greet.md
@@ -1,0 +1,51 @@
+# cli/greet.zpp
+
+## Traits
+
+### Greeter
+
+```zig
+trait Greeter
+```
+
+## Functions
+
+### pickGreeter
+
+```zig
+fn pickGreeter(locale_id: []const u8) ?dyn Greeter
+```
+
+### printHelp
+
+```zig
+fn printHelp() void
+```
+
+### printList
+
+```zig
+fn printList() void
+```
+
+### doGreet
+
+```zig
+fn doGreet(g: dyn Greeter, name: []const u8) void
+    requires(name.len > 0)
+```
+
+### main
+
+```zig
+pub fn main() !void
+```
+
+## Owned Structs
+
+### Args
+
+```zig
+owned struct Args
+```
+

--- a/docs/src/api/multi_file/main.md
+++ b/docs/src/api/multi_file/main.md
@@ -1,0 +1,10 @@
+# multi_file/main.zpp
+
+## Functions
+
+### main
+
+```zig
+pub fn main() !void
+```
+

--- a/docs/src/api/multi_file/util.md
+++ b/docs/src/api/multi_file/util.md
@@ -1,0 +1,18 @@
+# multi_file/util.zpp
+
+## Traits
+
+### Printer
+
+```zig
+trait Printer
+```
+
+## Functions
+
+### shoutAll
+
+```zig
+pub fn shoutAll(p: impl Printer, lines: []const []const u8) void
+```
+

--- a/docs/src/api/multi_file_pub/api.md
+++ b/docs/src/api/multi_file_pub/api.md
@@ -1,0 +1,10 @@
+# multi_file_pub/api.zpp
+
+## Traits
+
+### Logger
+
+```zig
+pub trait Logger
+```
+

--- a/docs/src/api/multi_file_pub/main.md
+++ b/docs/src/api/multi_file_pub/main.md
@@ -1,0 +1,16 @@
+# multi_file_pub/main.zpp
+
+## Functions
+
+### fanOut
+
+```zig
+fn fanOut(loggers: []const zpp.Dyn(api.Logger_VTable), msg: []const u8) void
+```
+
+### main
+
+```zig
+pub fn main() !void
+```
+

--- a/docs/src/output/cli_greet.txt
+++ b/docs/src/output/cli_greet.txt
@@ -1,0 +1,2 @@
+# greeting hash: a8d6c5c439a3decc
+こんにちは、Adaさん!

--- a/examples/cli/greet.zpp
+++ b/examples/cli/greet.zpp
@@ -1,0 +1,206 @@
+/// greet.zpp — small CLI tool demonstrating Zig++ end-to-end.
+///
+/// One file, six Zig++ features:
+///   trait      — Greeter, with three concrete impls
+///   impl       — for English / Japanese / Pirate
+///   dyn        — chosen at runtime from a string flag
+///   owned      — Args parses argv into an owned struct with deinit
+///   derive     — Greeting payload gets Hash + Eq + Debug
+///   requires   — locale-name length pre-check
+///
+/// Usage:
+///   greet [--locale en|ja|pirate] [name]   default: en, World
+///   greet --help
+///   greet --list
+///
+/// Run via:
+///   zpp run examples/cli/greet.zpp -- --locale ja Ada
+///   zpp run examples/cli/greet.zpp -- --list
+///   zpp run examples/cli/greet.zpp -- pirate Roger
+
+const std = @import("std");
+const zpp = @import("zpp");
+
+trait Greeter {
+    fn greet(self, name: []const u8) void;
+    fn locale(self) []const u8;
+}
+
+const English = struct {};
+const Japanese = struct {};
+const Pirate = struct {};
+
+// Zero-sized impl values held at module scope so dyn pointers into them
+// stay valid for the whole program's lifetime.
+var en_impl = English{};
+var ja_impl = Japanese{};
+var pi_impl = Pirate{};
+
+impl Greeter for English {
+    fn greet(self, name: []const u8) void {
+        _ = self;
+        std.debug.print("Hello, {s}!\n", .{name});
+    }
+    fn locale(self) []const u8 {
+        _ = self;
+        return "en";
+    }
+}
+
+impl Greeter for Japanese {
+    fn greet(self, name: []const u8) void {
+        _ = self;
+        std.debug.print("こんにちは、{s}さん!\n", .{name});
+    }
+    fn locale(self) []const u8 {
+        _ = self;
+        return "ja";
+    }
+}
+
+impl Greeter for Pirate {
+    fn greet(self, name: []const u8) void {
+        _ = self;
+        std.debug.print("Ahoy, {s}! Splice the mainbrace! 🏴‍☠️\n", .{name});
+    }
+    fn locale(self) []const u8 {
+        _ = self;
+        return "pirate";
+    }
+}
+
+const Greeting = struct {
+    locale_id: []const u8,
+    name: []const u8,
+} derive(.{ Hash, Eq, Debug });
+
+owned struct Args {
+    locale: []const u8,
+    name: []const u8,
+    show_list: bool,
+    show_help: bool,
+
+    pub fn init(allocator: std.mem.Allocator, argv: [][:0]u8) Args {
+        _ = allocator;
+        var out = Args{
+            .locale = "en",
+            .name = "World",
+            .show_list = false,
+            .show_help = false,
+        };
+        var i: usize = 1; // skip argv[0]
+        var positional: usize = 0;
+        var locale_via_flag = false;
+        while (i < argv.len) : (i += 1) {
+            const a = argv[i];
+            if (std.mem.eql(u8, a, "--help") or std.mem.eql(u8, a, "-h")) {
+                out.show_help = true;
+            } else if (std.mem.eql(u8, a, "--list")) {
+                out.show_list = true;
+            } else if (std.mem.eql(u8, a, "--locale") or std.mem.eql(u8, a, "-l")) {
+                if (i + 1 < argv.len) {
+                    i += 1;
+                    out.locale = argv[i];
+                    locale_via_flag = true;
+                }
+            } else {
+                // Positional: if --locale was used, all positionals are name.
+                // Otherwise positional[0] is locale, positional[1] is name.
+                if (locale_via_flag) {
+                    if (positional == 0) out.name = a;
+                } else {
+                    if (positional == 0) {
+                        out.locale = a;
+                    } else if (positional == 1) {
+                        out.name = a;
+                    }
+                }
+                positional += 1;
+            }
+        }
+        return out;
+    }
+
+    pub fn deinit(self: *Args) void {
+        // Args borrows slices from argv; nothing to free, but the
+        // owned-struct contract still requires a deinit.
+        _ = self;
+    }
+}
+
+fn pickGreeter(locale_id: []const u8) ?dyn Greeter {
+    if (std.mem.eql(u8, locale_id, "en")) {
+        return zpp.Dyn(Greeter_VTable).init(English, &en_impl, &Greeter_impl_for_English);
+    }
+    if (std.mem.eql(u8, locale_id, "ja")) {
+        return zpp.Dyn(Greeter_VTable).init(Japanese, &ja_impl, &Greeter_impl_for_Japanese);
+    }
+    if (std.mem.eql(u8, locale_id, "pirate")) {
+        return zpp.Dyn(Greeter_VTable).init(Pirate, &pi_impl, &Greeter_impl_for_Pirate);
+    }
+    return null;
+}
+
+fn printHelp() void {
+    std.debug.print(
+        \\greet — multi-locale greeter
+        \\
+        \\USAGE:
+        \\    greet [--locale <id>] [<name>]
+        \\    greet <locale> <name>
+        \\    greet --list
+        \\    greet --help
+        \\
+        \\Locales: en (default), ja, pirate
+        \\
+    , .{});
+}
+
+fn printList() void {
+    std.debug.print("Available locales:\n", .{});
+    inline for (.{ "en", "ja", "pirate" }) |loc| {
+        std.debug.print("  {s}\n", .{loc});
+    }
+}
+
+fn doGreet(g: dyn Greeter, name: []const u8) void
+    requires(name.len > 0)
+{
+    g.vtable.greet(g.ptr, name);
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const argv = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, argv);
+
+    using args = Args.init(allocator, argv);
+
+    if (args.show_help) {
+        printHelp();
+        return;
+    }
+    if (args.show_list) {
+        printList();
+        return;
+    }
+
+    // Build a Greeting payload. Hashing it is wholly cosmetic here —
+    // we just want to show that the derive helpers compose.
+    const payload = Greeting{ .locale_id = args.locale, .name = args.name };
+    std.debug.print("# greeting hash: {x}\n", .{payload.hash()});
+
+    // Static dispatch path is unused in this binary because the locale is
+    // chosen at runtime. We reach for `dyn` so all impls share one slot.
+    const maybe_g = pickGreeter(args.locale);
+    if (maybe_g) |g| {
+        _ = g.vtable.locale(g.ptr);
+        doGreet(g, args.name);
+    } else {
+        std.debug.print("error: unknown locale '{s}'. Try `greet --list`.\n", .{args.locale});
+        std.process.exit(1);
+    }
+}

--- a/examples/cli/greet.zpp
+++ b/examples/cli/greet.zpp
@@ -142,18 +142,15 @@ fn pickGreeter(locale_id: []const u8) ?dyn Greeter {
 }
 
 fn printHelp() void {
-    std.debug.print(
-        \\greet — multi-locale greeter
-        \\
-        \\USAGE:
-        \\    greet [--locale <id>] [<name>]
-        \\    greet <locale> <name>
-        \\    greet --list
-        \\    greet --help
-        \\
-        \\Locales: en (default), ja, pirate
-        \\
-    , .{});
+    // The Zig++ lexer doesn't yet recognise the `\\`-prefixed multi-line
+    // string form, so help is emitted as a sequence of regular prints.
+    std.debug.print("greet -- multi-locale greeter\n\n", .{});
+    std.debug.print("USAGE:\n", .{});
+    std.debug.print("    greet [--locale <id>] [<name>]\n", .{});
+    std.debug.print("    greet <locale> <name>\n", .{});
+    std.debug.print("    greet --list\n", .{});
+    std.debug.print("    greet --help\n\n", .{});
+    std.debug.print("Locales: en (default), ja, pirate\n", .{});
 }
 
 fn printList() void {


### PR DESCRIPTION
Closes #44. Adds examples/cli/greet.zpp combining 6 Zig++ features in one runnable CLI.

Also fixes a pre-existing lowerer bug: fn return types were not routed through writeRewrittenType, so `?dyn Trait` (and any Zig++ type sugar) in return position passed through verbatim and broke the build.

## Test plan
- [x] zig build all green
- [x] zig build e2e includes new example, green
- [x] manual CLI flows: default / --locale + name / positional locale + name / --list / --help / unknown locale