### PR TITLE
feat(vscode): status bar + openDocs + more snippets

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -26,7 +26,8 @@ official Zig extension.
   untitled `.zig` editor so you can see exactly what the compiler emits.
 - **Snippets** for `trait`, `impl`, `owned struct`, `using`, `dyn`,
   `derive`, `requires`, `ensures`, `effects`, `extern interface`, `own`,
-  and a `main` boilerplate. Type the prefix and press `Tab`.
+  `main`, plus `using_arena`, `dyn_init`, `task_group`, `effects_pure`,
+  and `pub_trait`. Type the prefix and press `Tab`.
 - **Hover with explanations**: hovering over a diagnostic line shows the
   long-form explanation of the diagnostic code plus a link to the docs
   site reference.
@@ -35,6 +36,12 @@ official Zig extension.
   open the long-form text in the output channel.
 - "Explain Diagnostic Code" command (`Cmd/Ctrl+Shift+E`) for direct
   lookup by code.
+- **Status bar item** that displays the detected `zpp` version (or a
+  hint when `zpp` is not on `PATH`) whenever a `.zpp` file is active.
+  Click it to jump straight to the docs.
+- **"Open Docs" command** (`zigpp.openDocs`, `Cmd/Ctrl+Shift+D`) opens
+  the [Zig++ docs site](https://nktkt.github.io/zigpp-lang/) in your
+  browser.
 - Bracket matching, auto-closing pairs, and word-pattern tuned for Zig
   identifiers.
 
@@ -82,6 +89,8 @@ code --install-extension zigpp-0.1.0.vsix
 | --- | --- | --- |
 | `Zig++: Run Current File` (`zigpp.run`) | `Ctrl+F5` (`Cmd+F5` on macOS) | Run `zpp run` on the active document and stream output. |
 | `Zig++: Show Lowered Zig` (`zigpp.lower`) | `Ctrl+Shift+L` (`Cmd+Shift+L` on macOS) | Run `zpp lower` and open the emitted Zig in a new editor. |
+| `Zig++: Explain Diagnostic Code` (`zigpp.explain`) | `Ctrl+Shift+E` (`Cmd+Shift+E` on macOS) | Look up the long-form explanation for a `Z####` diagnostic. |
+| `Zig++: Open Docs` (`zigpp.openDocs`) | `Ctrl+Shift+D` (`Cmd+Shift+D` on macOS) | Open the Zig++ docs site in your default browser. |
 
 ## Known limitations
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -81,6 +81,11 @@
         "command": "zigpp.explain",
         "title": "Zig++: Explain Diagnostic Code",
         "category": "Zig++"
+      },
+      {
+        "command": "zigpp.openDocs",
+        "title": "Zig++: Open Docs",
+        "category": "Zig++"
       }
     ],
     "keybindings": [
@@ -101,6 +106,11 @@
         "key": "ctrl+shift+e",
         "mac": "cmd+shift+e",
         "when": "editorTextFocus && editorLangId == zigpp"
+      },
+      {
+        "command": "zigpp.openDocs",
+        "key": "ctrl+shift+d",
+        "mac": "cmd+shift+d"
       }
     ]
   },

--- a/vscode/snippets/zigpp.json
+++ b/vscode/snippets/zigpp.json
@@ -104,5 +104,40 @@
       "}"
     ],
     "description": "Standard Zig++ entry point."
+  },
+  "using_arena": {
+    "prefix": "using_arena",
+    "body": ["using ${1:arena} = zpp.ArenaScope.init(${2:allocator});"],
+    "description": "RAII arena scope; auto-frees on scope exit."
+  },
+  "dyn_init": {
+    "prefix": "dyn_init",
+    "body": [
+      "zpp.Dyn(${1:VTable}).init(${2:Type}, &${3:val}, &${1:VTable}_impl_for_${2:Type})"
+    ],
+    "description": "Construct a dyn-dispatch trait object from a concrete value + vtable impl."
+  },
+  "task_group": {
+    "prefix": "task_group",
+    "body": [
+      "var ${1:group} = zpp.async_mod.TaskGroup.init(${2:allocator});",
+      "defer ${1:group}.deinit();",
+      "$0"
+    ],
+    "description": "Structured-concurrency task group with deferred deinit."
+  },
+  "effects_pure": {
+    "prefix": "effects_pure",
+    "body": ["effects(.noalloc, .noio)"],
+    "description": "Pure effect annotation: forbids allocation and I/O."
+  },
+  "pub_trait": {
+    "prefix": "pub_trait",
+    "body": [
+      "pub trait ${1:Name} {",
+      "    fn ${2:method}(self, ${3:args}) ${4:ret};",
+      "}"
+    ],
+    "description": "Public Zig++ trait declaration."
   }
 }

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -7,8 +7,13 @@ import {
   TransportKind,
 } from 'vscode-languageclient/node';
 
+const DOCS_URL = 'https://nktkt.github.io/zigpp-lang/';
+
 let client: LanguageClient | undefined;
 let outputChannel: vscode.OutputChannel | undefined;
+let statusBarItem: vscode.StatusBarItem | undefined;
+let zppVersion: string | undefined;
+let zppVersionResolved = false;
 
 function getOutputChannel(): vscode.OutputChannel {
   if (!outputChannel) {
@@ -177,6 +182,13 @@ function registerCommands(context: vscode.ExtensionContext): void {
     );
   });
 
+  const openDocsCommand = vscode.commands.registerCommand(
+    'zigpp.openDocs',
+    () => {
+      void vscode.env.openExternal(vscode.Uri.parse(DOCS_URL));
+    }
+  );
+
   const explainCommand = vscode.commands.registerCommand(
     'zigpp.explain',
     async (presupplied?: string) => {
@@ -236,7 +248,98 @@ function registerCommands(context: vscode.ExtensionContext): void {
     }
   );
 
-  context.subscriptions.push(runCommand, lowerCommand, explainCommand);
+  context.subscriptions.push(
+    runCommand,
+    lowerCommand,
+    explainCommand,
+    openDocsCommand
+  );
+}
+
+/**
+ * Spawn `zpp version` once and cache the trimmed first-line output.
+ * Resolves to undefined if the binary is not on PATH or exits non-zero.
+ */
+function detectZppVersion(): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    let stdout = '';
+    let settled = false;
+    const finish = (value: string | undefined): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    try {
+      const proc = cp.spawn('zpp', ['version'], {
+        cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+      });
+      proc.stdout.setEncoding('utf8');
+      proc.stdout.on('data', (chunk: string) => {
+        stdout += chunk;
+      });
+      proc.on('error', () => finish(undefined));
+      proc.on('exit', (code) => {
+        if (code !== 0) {
+          finish(undefined);
+          return;
+        }
+        const first = stdout.split(/\r?\n/)[0]?.trim();
+        finish(first && first.length > 0 ? first : undefined);
+      });
+    } catch {
+      finish(undefined);
+    }
+  });
+}
+
+function updateStatusBarVisibility(): void {
+  if (!statusBarItem) return;
+  const editor = vscode.window.activeTextEditor;
+  if (editor && editor.document.languageId === 'zigpp') {
+    statusBarItem.show();
+  } else {
+    statusBarItem.hide();
+  }
+}
+
+function applyVersionToStatusBar(): void {
+  if (!statusBarItem) return;
+  if (zppVersion) {
+    statusBarItem.text = `Zig++ ${zppVersion}`;
+    statusBarItem.tooltip = `Zig++ ${zppVersion} — click to open the docs site.`;
+  } else {
+    statusBarItem.text = 'Zig++ (zpp not found)';
+    statusBarItem.tooltip =
+      "Couldn't run 'zpp version'. Make sure the 'zpp' binary is on your PATH " +
+      "(build with 'zig build' and symlink 'zig-out/bin/zpp'). " +
+      'Click to open the docs site.';
+  }
+}
+
+async function setupStatusBar(
+  context: vscode.ExtensionContext
+): Promise<void> {
+  statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    100
+  );
+  statusBarItem.command = 'zigpp.openDocs';
+  statusBarItem.text = 'Zig++';
+  statusBarItem.tooltip = 'Zig++ — detecting zpp version…';
+  context.subscriptions.push(statusBarItem);
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(() =>
+      updateStatusBarVisibility()
+    )
+  );
+  updateStatusBarVisibility();
+
+  if (!zppVersionResolved) {
+    zppVersionResolved = true;
+    zppVersion = await detectZppVersion();
+  }
+  applyVersionToStatusBar();
+  updateStatusBarVisibility();
 }
 
 /**
@@ -291,10 +394,12 @@ export async function activate(
       { providedCodeActionKinds: ExplainCodeActionProvider.providedKinds }
     )
   );
+  void setupStatusBar(context);
   await startLanguageClient(context);
 }
 
 export async function deactivate(): Promise<void> {
+  statusBarItem = undefined;
   if (!client) {
     return;
   }


### PR DESCRIPTION
## Summary

Three small polish items for the Zig++ VS Code extension. No language semantics change.

- **Status bar item** (right): shows `Zig++ vX.Y.Z` while a `.zpp` file is active. Detected once at activation via `zpp version`, cached in module scope. Click opens the docs. Falls back to `Zig++ (zpp not found)` with a setup-hint tooltip when the binary is missing.
- **`zigpp.openDocs` command** bound to `Cmd/Ctrl+Shift+D` — opens https://nktkt.github.io/zigpp-lang/ via `vscode.env.openExternal`.
- **5 new snippets**: `using_arena`, `dyn_init`, `task_group`, `effects_pure`, `pub_trait`.

`vscode/README.md` and `vscode/package.json` (commands + keybindings) updated to reflect the new surface area.

## Test plan

- [x] `cd vscode && npm install && npm run compile` is clean (strict tsc, no errors)
- [x] `out/extension.js` includes references to `vscode.window.createStatusBarItem` and `zigpp.openDocs`
- [ ] In an Extension Development Host: open a `.zpp` file → status bar shows `Zig++ <version>`; switch to a non-`.zpp` file → it hides
- [ ] `Cmd/Ctrl+Shift+D` opens the docs site in the default browser
- [ ] Each new snippet expands cleanly (`using_arena`, `dyn_init`, `task_group`, `effects_pure`, `pub_trait`)
- [ ] Uninstalling `zpp` from PATH shows `Zig++ (zpp not found)` with the diagnostic tooltip

Co-authored-by Claude Opus 4.7.

Generated with Claude Code.