### PR TITLE
feat(sema): Z0021 borrow invalidated by move (MVP)

### DIFF
--- a/compiler/diagnostics.zig
+++ b/compiler/diagnostics.zig
@@ -40,6 +40,7 @@ pub const Code = enum {
     z0010_missing_deinit_on_owned,
     z0011_using_type_lacks_deinit,
     z0020_use_after_move,
+    z0021_borrow_invalidated_by_move,
     z0030_effect_violation,
     z0040_impl_missing_method,
     z0100_unexpected_token,
@@ -56,6 +57,7 @@ pub const Code = enum {
             .z0010_missing_deinit_on_owned => "Z0010",
             .z0011_using_type_lacks_deinit => "Z0011",
             .z0020_use_after_move => "Z0020",
+            .z0021_borrow_invalidated_by_move => "Z0021",
             .z0030_effect_violation => "Z0030",
             .z0040_impl_missing_method => "Z0040",
             .z0100_unexpected_token => "Z0100",
@@ -78,6 +80,7 @@ pub fn hint(code: Code) ?[]const u8 {
         .z0010_missing_deinit_on_owned => "owned structs must release their resources explicitly. Add:\n  pub fn deinit(self: *@This()) void {\n      // free anything held by `self`, then leave it in a moved-from state.\n  }",
         .z0011_using_type_lacks_deinit => "give the type a `deinit` method, or drop the `using` binding so the compiler does not try to auto-release it.",
         .z0020_use_after_move => "the value was consumed by `move`. Rebind it (`own var x = ...`) or restructure the code to keep a single owner.",
+        .z0021_borrow_invalidated_by_move => "the value still has an outstanding borrow (from `&x` or `&x.field`). End the borrow's scope before moving, or restructure to avoid the conflict.",
         .z0030_effect_violation => "the function declared an effect it then violated. Remove the `effects(...)` annotation or eliminate the disallowed operation (allocation, IO, etc.).",
         .z0040_impl_missing_method => "every method declared on the trait must be implemented. Add the listed missing methods, or drop the impl block if you do not intend to satisfy the trait.",
         .z0100_unexpected_token => "remove or replace the highlighted token. The parser was in the middle of a declaration or expression and could not continue.",
@@ -164,6 +167,31 @@ pub fn explain(code: Code) []const u8 {
         \\    use(b);
         \\
         \\Or restructure so each owner is read exactly once.
+        ,
+        .z0021_borrow_invalidated_by_move =>
+        \\Z0021: borrow invalidated by move
+        \\
+        \\A function-local borrow was taken (`&x` or `&x.field`) and then the
+        \\borrowed binding was consumed by `move x` while the borrow was
+        \\still in scope. After the move, the reference would dangle, so
+        \\sema rejects the move.
+        \\
+        \\Triggers:
+        \\    own var person = Person{ .name = "Ada" };
+        \\    const r = &person.name;
+        \\    const p = move person;     // r is still alive — invalid
+        \\    _ = r;
+        \\    _ = p;
+        \\
+        \\Fix (let the borrow end first):
+        \\    own var person = Person{ .name = "Ada" };
+        \\    {
+        \\        const r = &person.name;
+        \\        use(r);
+        \\    }
+        \\    const p = move person;     // OK, no live borrow
+        \\
+        \\Or restructure so the move and the borrow don't overlap.
         ,
         .z0030_effect_violation =>
         \\Z0030: function violates declared effect

--- a/compiler/sema.zig
+++ b/compiler/sema.zig
@@ -236,6 +236,12 @@ pub const Sema = struct {
         // are subject to affine checking.
         var own_names = std.StringHashMap(void).init(self.allocator);
         defer own_names.deinit();
+        // Borrow tracking (Z0021). For the MVP we only remember the FIRST
+        // `&x` per fn body (scope-local; the map is reset between fns). When
+        // we later see `move x` while `x` is borrowed we fire Z0021. Multi-
+        // borrow tracking (vector of spans per name) is a follow-up.
+        var borrows = std.StringHashMap(diag.Span).init(self.allocator);
+        defer borrows.deinit();
 
         for (body.stmts) |s| {
             switch (s) {
@@ -243,10 +249,24 @@ pub const Sema = struct {
                     try own_names.put(o.name, {});
                     // re-binding rescinds prior moved status
                     _ = moved.remove(o.name);
+                    // Re-bind also rescinds any outstanding borrow record:
+                    // the new value is a fresh binding.
+                    _ = borrows.remove(o.name);
+                    // The init expression itself may borrow another name.
+                    try self.recordBorrows(o.init_text, o.span, &borrows);
                 },
                 .move_expr_stmt => |m| {
                     if (own_names.contains(m.target)) {
                         try moved.put(m.target, m.span);
+                    }
+                    if (borrows.contains(m.target)) {
+                        try self.diags.emit(
+                            .err,
+                            .z0021_borrow_invalidated_by_move,
+                            m.span,
+                            "cannot move '{s}' while borrowed",
+                            .{m.target},
+                        );
                     }
                 },
                 .using_stmt => |u| {
@@ -259,6 +279,7 @@ pub const Sema = struct {
                             .{ u.name, prev.start },
                         );
                     }
+                    try self.recordBorrows(u.init_text, u.span, &borrows);
                 },
                 .raw => |raw| {
                     // First check uses against the moved set as it stands BEFORE
@@ -278,15 +299,108 @@ pub const Sema = struct {
                     }
                     // Then scan THIS statement's text for `move <ident>` patterns
                     // and record them so the next statement sees them as moved.
+                    // If the moved name has an outstanding borrow recorded
+                    // earlier in this function body, fire Z0021 instead of
+                    // (in addition to) Z0020.
                     var off: usize = 0;
                     while (findMoveTarget(raw.text, off)) |found| {
+                        if (borrows.contains(found.name)) {
+                            try self.diags.emit(
+                                .err,
+                                .z0021_borrow_invalidated_by_move,
+                                raw.span,
+                                "cannot move '{s}' while borrowed",
+                                .{found.name},
+                            );
+                        }
                         if (own_names.contains(found.name)) {
                             try moved.put(found.name, raw.span);
                         }
                         off = found.end;
                     }
+                    // Finally scan the same statement's text for new borrow
+                    // patterns (`&<ident>` / `&<ident>.field`) and record
+                    // the FIRST borrow per name. Order vs the move scan
+                    // above means a single stmt that borrows then moves is
+                    // not flagged — that's an acceptable false-negative
+                    // for the MVP (the heuristic is conservative).
+                    try self.recordBorrows(raw.text, raw.span, &borrows);
                 },
             }
+        }
+    }
+
+    /// Scan `text` for `&<ident>` (optionally followed by `.<field>`) and
+    /// record the FIRST borrow span per identifier into `borrows`. Skips
+    /// strings, char literals and `//` comments the same way `mentionsIdent`
+    /// does so that an `&x` mentioned in a debug message doesn't count as
+    /// a borrow.
+    fn recordBorrows(
+        self: *Sema,
+        text: []const u8,
+        span: diag.Span,
+        borrows: *std.StringHashMap(diag.Span),
+    ) !void {
+        _ = self;
+        var i: usize = 0;
+        while (i < text.len) {
+            const c = text[i];
+            // Skip over double-quoted string literals.
+            if (c == '"') {
+                i += 1;
+                while (i < text.len) : (i += 1) {
+                    if (text[i] == '\\' and i + 1 < text.len) { i += 1; continue; }
+                    if (text[i] == '"') { i += 1; break; }
+                }
+                continue;
+            }
+            // Skip over char literals.
+            if (c == '\'') {
+                i += 1;
+                while (i < text.len and text[i] != '\'') : (i += 1) {
+                    if (text[i] == '\\' and i + 1 < text.len) i += 1;
+                }
+                if (i < text.len) i += 1;
+                continue;
+            }
+            // Skip over `//` line comments.
+            if (c == '/' and i + 1 < text.len and text[i + 1] == '/') {
+                while (i < text.len and text[i] != '\n') i += 1;
+                continue;
+            }
+            if (c == '&') {
+                // Skip `&&` (short-circuit AND in patterns we may add later
+                // — Zig itself uses `and`, but be defensive).
+                if (i + 1 < text.len and text[i + 1] == '&') { i += 2; continue; }
+                // The `&` must be a prefix on an identifier — i.e. NOT
+                // preceded by an identifier char (which would make it a
+                // bitwise-and like `a & b`).
+                if (i > 0 and isIdent(text[i - 1])) { i += 1; continue; }
+                var j = i + 1;
+                // Permit a single leading `*` for `&*ptr` (Zig pointer deref
+                // followed by address-of is uncommon but harmless to skip).
+                while (j < text.len and (text[j] == ' ' or text[j] == '\t')) j += 1;
+                const name_start = j;
+                while (j < text.len and isIdent(text[j])) j += 1;
+                if (j > name_start) {
+                    const name = text[name_start..j];
+                    // Don't record borrows of obvious vtable / type names
+                    // (anything starting with an uppercase letter). The
+                    // heuristic is: lower-case-leading identifiers are
+                    // value bindings; capitalised ones are types/vtables.
+                    // This keeps existing examples (`&Handler_impl_for_X`)
+                    // out of the borrow set.
+                    const first = name[0];
+                    const is_value_ident = (first >= 'a' and first <= 'z') or first == '_';
+                    if (is_value_ident) {
+                        const gop = try borrows.getOrPut(name);
+                        if (!gop.found_existing) gop.value_ptr.* = span;
+                    }
+                    i = j;
+                    continue;
+                }
+            }
+            i += 1;
         }
     }
 

--- a/docs/src/v0.2-plan.md
+++ b/docs/src/v0.2-plan.md
@@ -64,7 +64,7 @@ dependency on the source tree.
 
 ---
 
-## 🟡 Field-level borrow checking
+## 🟡 Field-level borrow checking (MVP landed; design pass ongoing)
 
 Today `own var` + `move x` is a flat affine system: a name is moved
 or it isn't. There is no concept of borrowing a single field.
@@ -84,6 +84,18 @@ Constraints:
 - Borrow checker only fires inside a function body. No cross-fn
   inference.
 - `move` of a struct invalidates all outstanding borrows (Z0021).
+
+Status (MVP):
+- A purely text-based heuristic shipped with Z0021. It scans raw
+  stmt text in each fn body for `&<ident>` / `&<ident>.field` and
+  records the FIRST borrow per name. A subsequent `move <ident>`
+  while that borrow is recorded fires Z0021 ("cannot move 'x' while
+  borrowed"). Borrows are scope-local to each fn body — the map is
+  reset between fns.
+- No new keyword (`let_borrow`) yet — plain Zig `const r = &x.field;`
+  is enough to trigger the check.
+- Multi-borrow tracking, end-of-scope inference, and the
+  `enable_borrow_check` opt-in are still TODO.
 
 Risk: this is a meaningful complexity addition. May need a separate
 opt-in `enable_borrow_check = true` per file before becoming

--- a/tests/diagnostics/diags.zig
+++ b/tests/diagnostics/diags.zig
@@ -44,6 +44,57 @@ test "Z0020: use after move" {
     try std.testing.expect(hasCode(&result.diags, "Z0020"));
 }
 
+test "Z0021: move while borrowed (positive)" {
+    const a = std.testing.allocator;
+    const src =
+        \\fn run() void {
+        \\    own var x = Person{ .name = "Ada" };
+        \\    const r = &x.name;
+        \\    const y = move x;
+        \\    _ = r;
+        \\    _ = y;
+        \\}
+    ;
+    var result = try analyze(a, src);
+    defer result.diags.deinit();
+    try std.testing.expect(hasCode(&result.diags, "Z0021"));
+}
+
+test "Z0021: same code without borrow does not fire" {
+    const a = std.testing.allocator;
+    const src =
+        \\fn run() void {
+        \\    own var x = Person{ .name = "Ada" };
+        \\    const r = x.name;
+        \\    const y = move x;
+        \\    _ = r;
+        \\    _ = y;
+        \\}
+    ;
+    var result = try analyze(a, src);
+    defer result.diags.deinit();
+    try std.testing.expect(!hasCode(&result.diags, "Z0021"));
+}
+
+test "Z0021: borrow and move in different fns do not collide" {
+    const a = std.testing.allocator;
+    const src =
+        \\fn borrowOnly() void {
+        \\    var x = Person{ .name = "Ada" };
+        \\    const r = &x.name;
+        \\    _ = r;
+        \\}
+        \\fn moveOnly() void {
+        \\    own var x = Person{ .name = "Ada" };
+        \\    const y = move x;
+        \\    _ = y;
+        \\}
+    ;
+    var result = try analyze(a, src);
+    defer result.diags.deinit();
+    try std.testing.expect(!hasCode(&result.diags, "Z0021"));
+}
+
 test "Z0030: noalloc effect violated by allocator call" {
     const a = std.testing.allocator;
     const src =


### PR DESCRIPTION
## Summary

- Add Z0021 ("cannot move 'x' while borrowed") — a purely text-based heuristic borrow checker that fires when a value is `move`d while an outstanding `&<ident>` / `&<ident>.field` borrow is alive in the same fn body.
- Borrows are scope-local to each function body (the map resets between fns), tracking the FIRST borrow per name. Multi-borrow tracking and end-of-scope inference are explicit follow-ups.
- The heuristic skips strings, char literals and `//` comments (same as `mentionsIdent`) and conservatively excludes capitalised identifiers (vtable / type names) so existing examples like `&Handler_impl_for_Counter` are unaffected.

## Files

- `compiler/diagnostics.zig` — new `z0021_borrow_invalidated_by_move` Code variant with `id()` / `hint()` / `explain()`.
- `compiler/sema.zig` — new `recordBorrows` helper integrated into `checkMoves` across all stmt arms (`own_decl`, `using_stmt`, `move_expr_stmt`, `raw`).
- `tests/diagnostics/diags.zig` — three new tests (positive borrow→move, negative no-borrow, negative cross-fn).
- `docs/src/v0.2-plan.md` — mark borrow checking MVP as landed.

## Test plan

- [x] `zig build test` — 9 diags tests pass (was 6).
- [x] `zig build check` — all `examples/*.zpp` clean (no false positives).
- [x] `zig build all` — exit 0.

The detection deliberately scopes itself so a single statement that both borrows and moves the same name (rare) is NOT flagged — false negatives are acceptable for the MVP, false positives on existing examples are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)