### PR TITLE
chore(examples): cli/greet — restore multi-line string in printHelp

### DIFF
--- a/examples/cli/greet.zpp
+++ b/examples/cli/greet.zpp
@@ -142,15 +142,18 @@ fn pickGreeter(locale_id: []const u8) ?dyn Greeter {
 }
 
 fn printHelp() void {
-    // The Zig++ lexer doesn't yet recognise the `\\`-prefixed multi-line
-    // string form, so help is emitted as a sequence of regular prints.
-    std.debug.print("greet -- multi-locale greeter\n\n", .{});
-    std.debug.print("USAGE:\n", .{});
-    std.debug.print("    greet [--locale <id>] [<name>]\n", .{});
-    std.debug.print("    greet <locale> <name>\n", .{});
-    std.debug.print("    greet --list\n", .{});
-    std.debug.print("    greet --help\n\n", .{});
-    std.debug.print("Locales: en (default), ja, pirate\n", .{});
+    std.debug.print(
+        \\greet -- multi-locale greeter
+        \\
+        \\USAGE:
+        \\    greet [--locale <id>] [<name>]
+        \\    greet <locale> <name>
+        \\    greet --list
+        \\    greet --help
+        \\
+        \\Locales: en (default), ja, pirate
+        \\
+    , .{});
 }
 
 fn printList() void {


### PR DESCRIPTION
## Summary
Now that #51 landed, `\\`-prefixed multi-line strings flow through the lexer cleanly. Swap the `printHelp` workaround (multiple `std.debug.print` lines) back to a single block string. Output is byte-for-byte identical.

## Test plan
- [x] `zig build all`
- [x] `zpp run examples/cli/greet.zpp -- --help` prints the same text as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)