### PR TITLE
docs(examples): effects_pure — comment Z0030 demo block

### DIFF
--- a/examples/effects_pure.zpp
+++ b/examples/effects_pure.zpp
@@ -58,4 +58,17 @@ pub fn main() !void {
     const file_hash = try loadAndHash(allocator, tmp_path);
     std.debug.print("loadAndHash(..)              = {x}\n", .{file_hash});
     std.debug.print("(fnv1a is .noalloc/.noio; loadAndHash is .alloc/.io)\n", .{});
+
+    // ----------------------------------------------------------------
+    // Z0030 — uncomment to see the inference-based check fire:
+    //
+    //     fn lying() void effects(.noalloc) {
+    //         var gpa2 = std.heap.GeneralPurposeAllocator(.{}){};
+    //         _ = gpa2.allocator().alloc(u8, 16) catch return;
+    //     }
+    //
+    // The body calls `.alloc(...)`, so inference deduces the `.alloc`
+    // effect; the `.noalloc` annotation contradicts it, and sema emits
+    //   error: Z0030 fn declared .noalloc but inferred .alloc effect
+    // ----------------------------------------------------------------
 }


### PR DESCRIPTION
## Summary
Mirrors the convention introduced by #56 (\`examples/borrow_check.zpp\`): adds a commented BAD block to \`examples/effects_pure.zpp\` showing the exact \`effects(.noalloc)\` + allocating-body shape that PR #55's inference-based check now rejects with Z0030. Compilable code is unchanged.

## Why
With #55 landed, Z0030 went from \"specific lint\" to \"the inference said you lied.\" The example didn't show that case anywhere — readers had to grep \`tests/diagnostics/diags.zig\` to see what triggers it.

## Test plan
- [x] \`zig build all\`
- [x] Uncommenting the BAD block makes \`zpp check examples/effects_pure.zpp\` emit Z0030

🤖 Generated with [Claude Code](https://claude.com/claude-code)