### PR TITLE
feat(sema): Z0030 .io effect inference (round 2)

### DIFF
--- a/compiler/ast.zig
+++ b/compiler/ast.zig
@@ -40,7 +40,7 @@ pub const WhereClause = struct {
     span: diag.Span,
 };
 
-pub const EffectKind = enum { alloc, noalloc, io, panic, custom };
+pub const EffectKind = enum { alloc, noalloc, io, noio, panic, custom };
 
 pub const Effect = struct {
     kind: EffectKind,

--- a/compiler/diagnostics.zig
+++ b/compiler/diagnostics.zig
@@ -196,20 +196,31 @@ pub fn explain(code: Code) []const u8 {
         .z0030_effect_violation =>
         \\Z0030: function violates declared effect
         \\
-        \\You annotated a function with `effects(.noalloc)` (or another
-        \\restrictive effect) and then called something that violates it.
-        \\Effect annotations are checked by sema as a heuristic — identifiers
-        \\containing `Allocator`, `alloc`, `create`, etc. count as an
-        \\allocation site.
+        \\You annotated a function with `effects(.noalloc)` / `effects(.noio)`
+        \\(or another restrictive effect) and then called something that
+        \\violates it. Effect annotations are checked by sema as a heuristic:
+        \\
+        \\  - `.noalloc` checks for `.alloc(` / `.create(` / `.realloc(` /
+        \\    `.dupe(` calls in the body (after stripping strings/comments),
+        \\    plus transitive propagation via local same-file callees.
+        \\  - `.noio` checks for the `std.debug.print`, `std.fs.`, `std.io.`,
+        \\    `std.process.`, `std.net.`, `std.os.`, `std.posix.`,
+        \\    `try writer.`, `.writeAll(`, `.writeLine(`, `.print(`, `.read(`,
+        \\    `.openFile(`, and `.createFile(` substrings, plus the same
+        \\    transitive propagation.
         \\
         \\Triggers:
         \\    effects(.noalloc) fn pure(a: Allocator) !void {
         \\        const xs = try a.alloc(u8, 16);   // violates .noalloc
         \\        _ = xs;
         \\    }
+        \\    effects(.noio) fn quiet() void {
+        \\        std.debug.print("hi\n", .{});      // violates .noio
+        \\    }
         \\
-        \\Fix: drop the `effects(.noalloc)` annotation, or eliminate the
-        \\allocation (use a fixed buffer / arena owned by the caller).
+        \\Fix: drop the `effects(.noXXX)` annotation, or eliminate the
+        \\offending operation (use a fixed buffer / arena owned by the
+        \\caller for allocs; pass IO out via a writer the caller owns).
         ,
         .z0040_impl_missing_method =>
         \\Z0040: impl is missing trait method(s)

--- a/compiler/parser.zig
+++ b/compiler/parser.zig
@@ -634,6 +634,8 @@ pub const Parser = struct {
                 .noalloc
             else if (std.mem.eql(u8, text, "io"))
                 .io
+            else if (std.mem.eql(u8, text, "noio"))
+                .noio
             else if (std.mem.eql(u8, text, "panic"))
                 .panic
             else

--- a/compiler/sema.zig
+++ b/compiler/sema.zig
@@ -43,6 +43,7 @@ pub const Sema = struct {
         try self.checkParams(file, &result);
         try self.checkFunctions(file, &result);
         try self.checkEffectInference(file);
+        try self.checkIoEffectInference(file);
 
         return result;
     }
@@ -553,6 +554,126 @@ pub const Sema = struct {
             }
         }
     }
+
+    /// Round 2 of the effect-inference MVP: same shape as
+    /// `checkEffectInference` but for the `.io` / `.noio` pair instead of
+    /// `.alloc` / `.noalloc`. Kept as a parallel pass (rather than fused with
+    /// the `.alloc` pass) so the existing wiring is unchanged.
+    ///
+    /// Heuristic for "direct IO": the body text contains any of these
+    /// substrings (after stripping strings / chars / `//` comments):
+    ///   `std.debug.print`, `std.fs.`, `std.io.`, `std.process.`,
+    ///   `std.net.`, `std.os.`, `std.posix.`, `try writer.`, `.writeAll(`,
+    ///   `.writeLine(`, `.print(`, `.read(`, `.openFile(`, `.createFile(`.
+    /// The set is intentionally narrow — broaden in a follow-up PR, not
+    /// here.
+    fn checkIoEffectInference(self: *Sema, file: *const ast.File) !void {
+        var fns: std.ArrayList(*const ast.FnDecl) = .{};
+        defer fns.deinit(self.allocator);
+        for (file.decls) |*d| {
+            switch (d.*) {
+                .fn_decl => |*fd| try fns.append(self.allocator, fd),
+                .impl_block => |ib| for (ib.fns) |*fd| try fns.append(self.allocator, fd),
+                .owned_struct => |os| for (os.fns) |*fd| try fns.append(self.allocator, fd),
+                .struct_decl => |sd| for (sd.fns) |*fd| try fns.append(self.allocator, fd),
+                else => {},
+            }
+        }
+        if (fns.items.len == 0) return;
+
+        var name_to_idx = std.StringHashMap(usize).init(self.allocator);
+        defer name_to_idx.deinit();
+        for (fns.items, 0..) |fd, i| {
+            const gop = try name_to_idx.getOrPut(fd.sig.name);
+            if (!gop.found_existing) gop.value_ptr.* = i;
+        }
+
+        const N = fns.items.len;
+        const direct = try self.allocator.alloc(bool, N);
+        defer self.allocator.free(direct);
+        const direct_span = try self.allocator.alloc(diag.Span, N);
+        defer self.allocator.free(direct_span);
+        const inferred = try self.allocator.alloc(bool, N);
+        defer self.allocator.free(inferred);
+
+        const calls = try self.allocator.alloc(std.ArrayList(usize), N);
+        defer {
+            for (calls) |*c| c.deinit(self.allocator);
+            self.allocator.free(calls);
+        }
+        for (calls) |*c| c.* = .{};
+
+        for (fns.items, 0..) |fd, i| {
+            direct[i] = false;
+            direct_span[i] = fd.sig.span;
+            inferred[i] = false;
+            const body = fd.body orelse continue;
+            for (body.stmts) |s| {
+                const text = switch (s) {
+                    .raw => |r| r.text,
+                    .using_stmt => |u| u.init_text,
+                    .own_decl => |o| o.init_text,
+                    else => continue,
+                };
+                if (!direct[i] and bodyDoesIO(text)) {
+                    direct[i] = true;
+                    direct_span[i] = switch (s) {
+                        .raw => |r| r.span,
+                        .using_stmt => |u| u.span,
+                        .own_decl => |o| o.span,
+                        else => unreachable,
+                    };
+                }
+                try collectLocalCalls(text, &name_to_idx, &calls[i], self.allocator);
+            }
+            inferred[i] = direct[i];
+        }
+
+        var changed = true;
+        var rounds: usize = 0;
+        while (changed and rounds < N + 1) : (rounds += 1) {
+            changed = false;
+            for (fns.items, 0..) |_, i| {
+                if (inferred[i]) continue;
+                for (calls[i].items) |cid| {
+                    if (inferred[cid]) {
+                        inferred[i] = true;
+                        changed = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        for (fns.items, 0..) |fd, i| {
+            const ef = fd.sig.effects orelse continue;
+            var declared_noio = false;
+            for (ef.effects) |e| {
+                if (e.kind == .noio) declared_noio = true;
+            }
+            if (!declared_noio) continue;
+            if (!inferred[i]) continue;
+
+            const span = if (direct[i]) direct_span[i] else fd.sig.span;
+            if (direct[i]) {
+                try self.diags.emit(
+                    .err,
+                    .z0030_effect_violation,
+                    span,
+                    "fn '{s}' declared .noio but inferred .io effect",
+                    .{fd.sig.name},
+                );
+            } else {
+                try self.diags.emit(
+                    .err,
+                    .z0030_effect_violation,
+                    span,
+                    "fn '{s}' declared .noio but inferred .io effect (transitively via a callee)",
+                    .{fd.sig.name},
+                );
+            }
+        }
+    }
 };
 
 /// Heuristic: does `text` look like an allocator-using call? We check for
@@ -614,6 +735,70 @@ fn bodyAllocates(text: []const u8) bool {
                 {
                     return true;
                 }
+            }
+        }
+        i += 1;
+    }
+    return false;
+}
+
+/// Heuristic for "this body performs IO": scan `text` for any of the
+/// substrings below, after stripping string / char literals and `//` line
+/// comments. The set is intentionally narrow — keep it documented next to
+/// the docs/src/v0.2-plan.md "Effect inference" section before adding more.
+///
+///   `std.debug.print`, `std.fs.`, `std.io.`, `std.process.`, `std.net.`,
+///   `std.os.`, `std.posix.`, `try writer.`, `.writeAll(`, `.writeLine(`,
+///   `.print(`, `.read(`, `.openFile(`, `.createFile(`.
+fn bodyDoesIO(text: []const u8) bool {
+    const needles = [_][]const u8{
+        "std.debug.print",
+        "std.fs.",
+        "std.io.",
+        "std.process.",
+        "std.net.",
+        "std.os.",
+        "std.posix.",
+        "try writer.",
+        ".writeAll(",
+        ".writeLine(",
+        ".print(",
+        ".read(",
+        ".openFile(",
+        ".createFile(",
+    };
+    var i: usize = 0;
+    while (i < text.len) {
+        const c = text[i];
+        // Skip over double-quoted string literals.
+        if (c == '"') {
+            i += 1;
+            while (i < text.len) : (i += 1) {
+                if (text[i] == '\\' and i + 1 < text.len) { i += 1; continue; }
+                if (text[i] == '"') { i += 1; break; }
+            }
+            continue;
+        }
+        // Skip over char literals.
+        if (c == '\'') {
+            i += 1;
+            while (i < text.len and text[i] != '\'') : (i += 1) {
+                if (text[i] == '\\' and i + 1 < text.len) i += 1;
+            }
+            if (i < text.len) i += 1;
+            continue;
+        }
+        // Skip over `//` line comments.
+        if (c == '/' and i + 1 < text.len and text[i + 1] == '/') {
+            while (i < text.len and text[i] != '\n') i += 1;
+            continue;
+        }
+        // Try every substring at this position.
+        inline for (needles) |needle| {
+            if (i + needle.len <= text.len and
+                std.mem.eql(u8, text[i .. i + needle.len], needle))
+            {
+                return true;
             }
         }
         i += 1;

--- a/docs/src/v0.2-plan.md
+++ b/docs/src/v0.2-plan.md
@@ -186,10 +186,28 @@ Done (MVP):
   exactly once) pairs added alongside the existing direct-call
   Z0030 test.
 
+Done (round 2: `.io` / `.noio`):
+- `compiler/sema.zig`: `checkIoEffectInference` runs as a parallel
+  pass right after the `.alloc` one. Same shape (collect fns →
+  build name → idx → seed direct hits → fixed-point propagate →
+  emit Z0030). The "direct IO" heuristic looks for these
+  substrings in body text (after stripping strings / chars /
+  `//` comments): `std.debug.print`, `std.fs.`, `std.io.`,
+  `std.process.`, `std.net.`, `std.os.`, `std.posix.`,
+  `try writer.`, `.writeAll(`, `.writeLine(`, `.print(`, `.read(`,
+  `.openFile(`, `.createFile(`. Set is intentionally narrow —
+  broaden in a follow-up PR.
+- `compiler/ast.zig` + `compiler/parser.zig`: `EffectKind` gained
+  `.noio`; the parser now recognises `effects(.noio)`.
+- `compiler/diagnostics.zig`: Z0030 long-form description covers
+  both the `.noalloc` and `.noio` variants.
+- `tests/diagnostics/diags.zig`: positive (`.noio` matches
+  inference, no Z0030) and negative (`.noio` fn that does IO
+  fires Z0030) tests added.
+
 Still TODO:
 - `@effectsOf(f)` queryable surface — separate proposal.
-- Inference for `.io`, `.panic`, and other effect kinds (only
-  `.alloc` / `.noalloc` is wired today).
+- Inference for `.panic` and `.custom` effect kinds.
 - Cross-file effect propagation. Today only fns declared in the
   same file are considered when propagating; a `.noalloc` fn that
   calls into an imported allocating fn is silently accepted.

--- a/tests/diagnostics/diags.zig
+++ b/tests/diagnostics/diags.zig
@@ -185,3 +185,35 @@ test "Z0030: noalloc fn that transitively allocates fires once" {
     }
     try std.testing.expectEqual(@as(usize, 1), z0030_count);
 }
+
+// --- Z0030 .io effect inference (round 2) ---
+
+test "Z0030: noio annotation matches inference does not fire" {
+    // `helper` is a pure arithmetic fn and `quiet` only calls it. Neither
+    // touches the IO heuristic substrings, so inference agrees with the
+    // `.noio` annotation and Z0030 must not fire.
+    const a = std.testing.allocator;
+    const src =
+        \\fn helper(x: i32) i32 { return x + 1; }
+        \\effects(.noio) fn quiet(x: i32) i32 {
+        \\    return helper(x) * 2;
+        \\}
+    ;
+    var result = try analyze(a, src);
+    defer result.diags.deinit();
+    try std.testing.expect(!hasCode(&result.diags, "Z0030"));
+}
+
+test "Z0030: noio fn that does IO fires" {
+    // `noisy` declares .noio but the body literally contains
+    // `std.debug.print`, which is in the IO heuristic. Z0030 must fire.
+    const a = std.testing.allocator;
+    const src =
+        \\effects(.noio) fn noisy() void {
+        \\    std.debug.print("hi\n", .{});
+        \\}
+    ;
+    var result = try analyze(a, src);
+    defer result.diags.deinit();
+    try std.testing.expect(hasCode(&result.diags, "Z0030"));
+}

--- a/tests/fuzz/grammar.zig
+++ b/tests/fuzz/grammar.zig
@@ -47,7 +47,7 @@ const type_pool_basic = [_][]const u8{
     "?i32", "[]i32", "*i32", "*const u8", "anyerror!void", "[*]u8",
 };
 
-const effect_pool = [_][]const u8{ "alloc", "noalloc", "io", "panic", "custom" };
+const effect_pool = [_][]const u8{ "alloc", "noalloc", "io", "noio", "panic", "custom" };
 const derive_pool = [_][]const u8{ "Hash", "Eq", "Debug", "Json", "Clone" };
 
 fn pickIdent(rng: *Random) []const u8 {


### PR DESCRIPTION
## Summary

Adds round 2 of the effect-inference MVP (PR #55 was round 1 for `.alloc`). A parallel pass over the local call graph flags any fn declaring `effects(.noio)` whose body (directly or transitively via local same-file callees) performs IO.

- `compiler/sema.zig`: `checkIoEffectInference` runs after `checkEffectInference`, same shape (collect fns -> name->idx -> seed direct hits -> fixed-point propagate -> emit Z0030).
- `compiler/ast.zig` + `compiler/parser.zig`: `EffectKind` gained `.noio`; the parser now recognises `effects(.noio)`.
- `compiler/diagnostics.zig`: Z0030 long-form description covers both `.noalloc` and `.noio`.
- `docs/src/v0.2-plan.md`: `.io` moved from "Still TODO" to a new "Done (round 2)" subsection.
- `tests/fuzz/grammar.zig`: `noio` added to the effect pool.

## Heuristic substrings (kept narrow on purpose — broaden in a follow-up)

`std.debug.print`, `std.fs.`, `std.io.`, `std.process.`, `std.net.`, `std.os.`, `std.posix.`, `try writer.`, `.writeAll(`, `.writeLine(`, `.print(`, `.read(`, `.openFile(`, `.createFile(`

The scanner reuses the same string / char / `//` comment skipping harness as the `.alloc` heuristic, so doc strings and error messages don't false-fire.

## New tests (`tests/diagnostics/diags.zig`)

1. `Z0030: noio annotation matches inference does not fire` — `.noio` fn that only calls a pure helper -> no diag.
2. `Z0030: noio fn that does IO fires` — `.noio` fn whose body contains `std.debug.print(...)` -> Z0030 fires.

## Test plan

- [x] `zig build test` exits 0
- [x] `zig build all` exits 0 (examples, e2e, bench)
- [x] Existing `.alloc` Z0030 tests still pass
- [x] `examples/effects_pure.zpp` (which already uses `.noio` on `fnv1a` and `.io` on `loadAndHash`) still compiles cleanly

## Out of scope

- `.panic` / `.custom` inference
- `@effectsOf(f)` queryable
- Cross-file propagation
- Fusing the `.alloc` and `.io` passes into a single bitfield walk