### PR TITLE
feat(sema): Z0030 .panic effect inference (round 3)

### DIFF
--- a/compiler/ast.zig
+++ b/compiler/ast.zig
@@ -40,7 +40,7 @@ pub const WhereClause = struct {
     span: diag.Span,
 };
 
-pub const EffectKind = enum { alloc, noalloc, io, noio, panic, custom };
+pub const EffectKind = enum { alloc, noalloc, io, noio, panic, nopanic, custom };
 
 pub const Effect = struct {
     kind: EffectKind,

--- a/compiler/diagnostics.zig
+++ b/compiler/diagnostics.zig
@@ -197,8 +197,9 @@ pub fn explain(code: Code) []const u8 {
         \\Z0030: function violates declared effect
         \\
         \\You annotated a function with `effects(.noalloc)` / `effects(.noio)`
-        \\(or another restrictive effect) and then called something that
-        \\violates it. Effect annotations are checked by sema as a heuristic:
+        \\/ `effects(.nopanic)` (or another restrictive effect) and then
+        \\called something that violates it. Effect annotations are checked
+        \\by sema as a heuristic:
         \\
         \\  - `.noalloc` checks for `.alloc(` / `.create(` / `.realloc(` /
         \\    `.dupe(` calls in the body (after stripping strings/comments),
@@ -208,6 +209,11 @@ pub fn explain(code: Code) []const u8 {
         \\    `try writer.`, `.writeAll(`, `.writeLine(`, `.print(`, `.read(`,
         \\    `.openFile(`, and `.createFile(` substrings, plus the same
         \\    transitive propagation.
+        \\  - `.nopanic` checks for `@panic(`, `unreachable` (as a
+        \\    statement, not inside an expression chain),
+        \\    `std.debug.assert(`, `std.debug.panic(`, and
+        \\    `std.process.exit(` substrings, plus the same transitive
+        \\    propagation.
         \\
         \\Triggers:
         \\    effects(.noalloc) fn pure(a: Allocator) !void {
@@ -217,10 +223,14 @@ pub fn explain(code: Code) []const u8 {
         \\    effects(.noio) fn quiet() void {
         \\        std.debug.print("hi\n", .{});      // violates .noio
         \\    }
+        \\    effects(.nopanic) fn safe(x: ?u32) u32 {
+        \\        return x orelse @panic("nope");    // violates .nopanic
+        \\    }
         \\
         \\Fix: drop the `effects(.noXXX)` annotation, or eliminate the
         \\offending operation (use a fixed buffer / arena owned by the
-        \\caller for allocs; pass IO out via a writer the caller owns).
+        \\caller for allocs; pass IO out via a writer the caller owns;
+        \\replace panics with explicit error returns).
         ,
         .z0040_impl_missing_method =>
         \\Z0040: impl is missing trait method(s)

--- a/compiler/parser.zig
+++ b/compiler/parser.zig
@@ -638,6 +638,8 @@ pub const Parser = struct {
                 .noio
             else if (std.mem.eql(u8, text, "panic"))
                 .panic
+            else if (std.mem.eql(u8, text, "nopanic"))
+                .nopanic
             else
                 .custom;
             try list.append(self.allocator, .{ .kind = kind, .text = text });

--- a/compiler/sema.zig
+++ b/compiler/sema.zig
@@ -44,6 +44,7 @@ pub const Sema = struct {
         try self.checkFunctions(file, &result);
         try self.checkEffectInference(file);
         try self.checkIoEffectInference(file);
+        try self.checkPanicEffectInference(file);
 
         return result;
     }
@@ -674,6 +675,129 @@ pub const Sema = struct {
             }
         }
     }
+
+    /// Round 3 of the effect-inference MVP: same shape as
+    /// `checkEffectInference` but for the `.panic` / `.nopanic` pair. Run as
+    /// a parallel pass after `.alloc` and `.io` so existing wiring stays
+    /// untouched.
+    ///
+    /// Heuristic for "direct panic": the body text contains any of these
+    /// substrings (after stripping strings / chars / `//` line comments):
+    ///   `@panic(`, `std.debug.assert(`, `std.debug.panic(`,
+    ///   `std.process.exit(`, plus a NARROWED check for `unreachable` —
+    ///   the bare keyword must follow either a newline or `=>` (so a
+    ///   switch arm `else => unreachable` counts but `a or unreachable`
+    ///   inside a long boolean chain does not). The narrowing keeps
+    ///   examples that mention `unreachable` only inside doc comments or
+    ///   quoted strings safe; the harness already strips strings so the
+    ///   primary risk was idiomatic boolean chains.
+    fn checkPanicEffectInference(self: *Sema, file: *const ast.File) !void {
+        var fns: std.ArrayList(*const ast.FnDecl) = .{};
+        defer fns.deinit(self.allocator);
+        for (file.decls) |*d| {
+            switch (d.*) {
+                .fn_decl => |*fd| try fns.append(self.allocator, fd),
+                .impl_block => |ib| for (ib.fns) |*fd| try fns.append(self.allocator, fd),
+                .owned_struct => |os| for (os.fns) |*fd| try fns.append(self.allocator, fd),
+                .struct_decl => |sd| for (sd.fns) |*fd| try fns.append(self.allocator, fd),
+                else => {},
+            }
+        }
+        if (fns.items.len == 0) return;
+
+        var name_to_idx = std.StringHashMap(usize).init(self.allocator);
+        defer name_to_idx.deinit();
+        for (fns.items, 0..) |fd, i| {
+            const gop = try name_to_idx.getOrPut(fd.sig.name);
+            if (!gop.found_existing) gop.value_ptr.* = i;
+        }
+
+        const N = fns.items.len;
+        const direct = try self.allocator.alloc(bool, N);
+        defer self.allocator.free(direct);
+        const direct_span = try self.allocator.alloc(diag.Span, N);
+        defer self.allocator.free(direct_span);
+        const inferred = try self.allocator.alloc(bool, N);
+        defer self.allocator.free(inferred);
+
+        const calls = try self.allocator.alloc(std.ArrayList(usize), N);
+        defer {
+            for (calls) |*c| c.deinit(self.allocator);
+            self.allocator.free(calls);
+        }
+        for (calls) |*c| c.* = .{};
+
+        for (fns.items, 0..) |fd, i| {
+            direct[i] = false;
+            direct_span[i] = fd.sig.span;
+            inferred[i] = false;
+            const body = fd.body orelse continue;
+            for (body.stmts) |s| {
+                const text = switch (s) {
+                    .raw => |r| r.text,
+                    .using_stmt => |u| u.init_text,
+                    .own_decl => |o| o.init_text,
+                    else => continue,
+                };
+                if (!direct[i] and bodyMayPanic(text)) {
+                    direct[i] = true;
+                    direct_span[i] = switch (s) {
+                        .raw => |r| r.span,
+                        .using_stmt => |u| u.span,
+                        .own_decl => |o| o.span,
+                        else => unreachable,
+                    };
+                }
+                try collectLocalCalls(text, &name_to_idx, &calls[i], self.allocator);
+            }
+            inferred[i] = direct[i];
+        }
+
+        var changed = true;
+        var rounds: usize = 0;
+        while (changed and rounds < N + 1) : (rounds += 1) {
+            changed = false;
+            for (fns.items, 0..) |_, i| {
+                if (inferred[i]) continue;
+                for (calls[i].items) |cid| {
+                    if (inferred[cid]) {
+                        inferred[i] = true;
+                        changed = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        for (fns.items, 0..) |fd, i| {
+            const ef = fd.sig.effects orelse continue;
+            var declared_nopanic = false;
+            for (ef.effects) |e| {
+                if (e.kind == .nopanic) declared_nopanic = true;
+            }
+            if (!declared_nopanic) continue;
+            if (!inferred[i]) continue;
+
+            const span = if (direct[i]) direct_span[i] else fd.sig.span;
+            if (direct[i]) {
+                try self.diags.emit(
+                    .err,
+                    .z0030_effect_violation,
+                    span,
+                    "fn '{s}' declared .nopanic but inferred .panic effect",
+                    .{fd.sig.name},
+                );
+            } else {
+                try self.diags.emit(
+                    .err,
+                    .z0030_effect_violation,
+                    span,
+                    "fn '{s}' declared .nopanic but inferred .panic effect (transitively via a callee)",
+                    .{fd.sig.name},
+                );
+            }
+        }
+    }
 };
 
 /// Heuristic: does `text` look like an allocator-using call? We check for
@@ -799,6 +923,101 @@ fn bodyDoesIO(text: []const u8) bool {
                 std.mem.eql(u8, text[i .. i + needle.len], needle))
             {
                 return true;
+            }
+        }
+        i += 1;
+    }
+    return false;
+}
+
+/// Heuristic for "this body may panic": scan `text` for any of the
+/// substrings below, after stripping string / char literals and `//` line
+/// comments. The set is intentionally small — keep it documented next to
+/// the docs/src/v0.2-plan.md "Effect inference" section before adding more.
+///
+///   `@panic(`, `std.debug.assert(`, `std.debug.panic(`,
+///   `std.process.exit(`, plus a NARROWED `unreachable` check (must
+///   appear at a stmt-like position — preceded by `\n` or `=>`).
+///
+/// The `unreachable` narrowing avoids firing on idiomatic Zig boolean
+/// chains like `cond or unreachable` inside expressions; it still
+/// catches the common switch-arm form `else => unreachable` and
+/// stand-alone `unreachable;` statements.
+fn bodyMayPanic(text: []const u8) bool {
+    const needles = [_][]const u8{
+        "@panic(",
+        "std.debug.assert(",
+        "std.debug.panic(",
+        "std.process.exit(",
+    };
+    var i: usize = 0;
+    while (i < text.len) {
+        const c = text[i];
+        // Skip over double-quoted string literals.
+        if (c == '"') {
+            i += 1;
+            while (i < text.len) : (i += 1) {
+                if (text[i] == '\\' and i + 1 < text.len) { i += 1; continue; }
+                if (text[i] == '"') { i += 1; break; }
+            }
+            continue;
+        }
+        // Skip over char literals.
+        if (c == '\'') {
+            i += 1;
+            while (i < text.len and text[i] != '\'') : (i += 1) {
+                if (text[i] == '\\' and i + 1 < text.len) i += 1;
+            }
+            if (i < text.len) i += 1;
+            continue;
+        }
+        // Skip over `//` line comments.
+        if (c == '/' and i + 1 < text.len and text[i + 1] == '/') {
+            while (i < text.len and text[i] != '\n') i += 1;
+            continue;
+        }
+        // Try every fixed-string substring at this position.
+        inline for (needles) |needle| {
+            if (i + needle.len <= text.len and
+                std.mem.eql(u8, text[i .. i + needle.len], needle))
+            {
+                return true;
+            }
+        }
+        // Narrowed `unreachable` check: bare keyword at a stmt-like
+        // position. Must be preceded by either start-of-text, `\n`, `;`,
+        // `{`, `}`, or follow a `=>` (after optional whitespace) so that
+        // switch arms like `else => unreachable` count, but a chain like
+        // `(cond or unreachable)` does not.
+        if (c == 'u' and i + "unreachable".len <= text.len and
+            std.mem.eql(u8, text[i .. i + "unreachable".len], "unreachable"))
+        {
+            // It must be a whole token (not a prefix of `unreachableX`).
+            const after_idx = i + "unreachable".len;
+            const is_word_boundary_after = after_idx >= text.len or !isIdent(text[after_idx]);
+            // It must not be part of a longer identifier on the left.
+            const is_word_boundary_before = i == 0 or !isIdent(text[i - 1]);
+            if (is_word_boundary_after and is_word_boundary_before) {
+                // Walk backwards over spaces / tabs to find the previous
+                // non-space byte and decide whether the position looks
+                // statement-like.
+                var k: usize = i;
+                while (k > 0) {
+                    k -= 1;
+                    const pc = text[k];
+                    if (pc == ' ' or pc == '\t') continue;
+                    // `=>` arm form.
+                    if (pc == '>' and k > 0 and text[k - 1] == '=') return true;
+                    // Stmt boundaries.
+                    if (pc == '\n' or pc == ';' or pc == '{' or pc == '}') return true;
+                    break;
+                }
+                // If we walked all the way to the start of text it's also a
+                // statement-like position (bare body of a fn).
+                if (k == 0) {
+                    const pc = text[0];
+                    if (pc == ' ' or pc == '\t' or pc == '\n') return true;
+                }
             }
         }
         i += 1;

--- a/docs/src/v0.2-plan.md
+++ b/docs/src/v0.2-plan.md
@@ -205,9 +205,31 @@ Done (round 2: `.io` / `.noio`):
   inference, no Z0030) and negative (`.noio` fn that does IO
   fires Z0030) tests added.
 
+Done (round 3: `.panic` / `.nopanic`):
+- `compiler/sema.zig`: `checkPanicEffectInference` runs as a third
+  parallel pass right after the `.io` one. Same shape (collect
+  fns → build name → idx → seed direct hits → fixed-point
+  propagate → emit Z0030). The "direct panic" heuristic looks
+  for these substrings in body text (after stripping strings /
+  chars / `//` comments): `@panic(`, `std.debug.assert(`,
+  `std.debug.panic(`, `std.process.exit(`, plus a NARROWED
+  `unreachable` check — the bare keyword must appear at a
+  stmt-like position (preceded by start-of-text, `\n`, `;`,
+  `{`, `}`, or `=>`) so switch arms `else => unreachable` and
+  bare `unreachable;` statements count, but boolean chains like
+  `cond or unreachable` do not. Set is intentionally narrow —
+  broaden in a follow-up PR.
+- `compiler/ast.zig` + `compiler/parser.zig`: `EffectKind` gained
+  `.nopanic`; the parser now recognises `effects(.nopanic)`.
+- `compiler/diagnostics.zig`: Z0030 long-form description covers
+  the `.nopanic` variant alongside `.noalloc` and `.noio`.
+- `tests/diagnostics/diags.zig`: positive (`.nopanic` matches
+  inference, no Z0030) and negative (`.nopanic` fn that
+  `@panic`s fires Z0030) tests added.
+
 Still TODO:
 - `@effectsOf(f)` queryable surface — separate proposal.
-- Inference for `.panic` and `.custom` effect kinds.
+- Inference for `.custom` effect kinds.
 - Cross-file effect propagation. Today only fns declared in the
   same file are considered when propagating; a `.noalloc` fn that
   calls into an imported allocating fn is silently accepted.

--- a/tests/diagnostics/diags.zig
+++ b/tests/diagnostics/diags.zig
@@ -217,3 +217,33 @@ test "Z0030: noio fn that does IO fires" {
     defer result.diags.deinit();
     try std.testing.expect(hasCode(&result.diags, "Z0030"));
 }
+
+test "Z0030: nopanic annotation matches inference does not fire" {
+    // `helper` is a pure arithmetic fn and `safe` only calls it. Neither
+    // body contains any of the panic heuristic substrings, so inference
+    // agrees with the `.nopanic` annotation and Z0030 must not fire.
+    const a = std.testing.allocator;
+    const src =
+        \\fn helper(x: i32) i32 { return x + 1; }
+        \\effects(.nopanic) fn safe(x: i32) i32 {
+        \\    return helper(x) * 2;
+        \\}
+    ;
+    var result = try analyze(a, src);
+    defer result.diags.deinit();
+    try std.testing.expect(!hasCode(&result.diags, "Z0030"));
+}
+
+test "Z0030: nopanic fn that panics fires" {
+    // `boom` declares .nopanic but the body literally contains
+    // `@panic(`, which is in the panic heuristic. Z0030 must fire.
+    const a = std.testing.allocator;
+    const src =
+        \\effects(.nopanic) fn boom() void {
+        \\    @panic("nope");
+        \\}
+    ;
+    var result = try analyze(a, src);
+    defer result.diags.deinit();
+    try std.testing.expect(hasCode(&result.diags, "Z0030"));
+}

--- a/tests/fuzz/grammar.zig
+++ b/tests/fuzz/grammar.zig
@@ -47,7 +47,7 @@ const type_pool_basic = [_][]const u8{
     "?i32", "[]i32", "*i32", "*const u8", "anyerror!void", "[*]u8",
 };
 
-const effect_pool = [_][]const u8{ "alloc", "noalloc", "io", "noio", "panic", "custom" };
+const effect_pool = [_][]const u8{ "alloc", "noalloc", "io", "noio", "panic", "nopanic", "custom" };
 const derive_pool = [_][]const u8{ "Hash", "Eq", "Debug", "Json", "Clone" };
 
 fn pickIdent(rng: *Random) []const u8 {


### PR DESCRIPTION
## Summary

Round 3 of the effect-inference MVP. Adds a parallel `.panic` / `.nopanic`
pass alongside `.alloc` (round 1, PR #55) and `.io` (round 2, PR #62). A
function declaring `effects(.nopanic)` whose body or any local same-file
callee directly panics now fires Z0030.

## Heuristic substrings

After stripping string literals, char literals, and `//` line comments:

- `@panic(`
- `std.debug.assert(`
- `std.debug.panic(`
- `std.process.exit(`
- `unreachable` — **narrowed**: the bare keyword must appear at a
  stmt-like position (preceded by start-of-text, `\n`, `;`, `{`, `}`,
  or `=>`). This is so switch arms `else => unreachable` count but
  boolean chains like `cond or unreachable` inside an expression do not
  trigger false positives.

Plus the existing `try f(...)` / `f(...)` local-callee scan: a fn
inherits `.panic` from any same-file callee that infers `.panic`,
propagated to a fixed point.

## Files touched

- `compiler/sema.zig` — `checkPanicEffectInference` + `bodyMayPanic`
  helper; pass invoked from `analyze()` after the `.io` pass.
- `compiler/ast.zig` — `EffectKind` gains `.nopanic`.
- `compiler/parser.zig` — recognises `effects(.nopanic)`.
- `compiler/diagnostics.zig` — Z0030 long-form description now
  documents the `.nopanic` heuristic alongside `.noalloc` / `.noio`.
- `tests/diagnostics/diags.zig` — 2 new tests (positive + negative).
- `tests/fuzz/grammar.zig` — `nopanic` added to the effect pool.
- `docs/src/v0.2-plan.md` — new "Done (round 3)" subsection;
  `.panic` removed from "Still TODO".

## New tests (2)

1. `Z0030: nopanic annotation matches inference does not fire` — a
   `.nopanic` fn calling a pure helper produces no Z0030.
2. `Z0030: nopanic fn that panics fires` — a `.nopanic` fn whose body
   contains `@panic(...)` produces Z0030.

## Test plan

- [x] `zig build test` exits 0 (240 tests pass; was 238 before)
- [x] `zig build all` exits 0
- [x] Existing `.alloc` / `.io` tests unchanged
- [x] No `.zpp` files in `examples/` / `tests/` declare `.nopanic`
      today, so no examples flipped to fire Z0030

## Out of scope (separate PRs)

- `.custom` effects.
- `@effectsOf(f)` queryable.
- Cross-file propagation.
- Reworking `EffectKind` storage (the three passes still duplicate
  the bookkeeping; that's fine for the MVP).

Generated with Claude Code.