### PR TITLE
feat(sema): .custom("name") effects + Z0060 (round 5)

### DIFF
--- a/compiler/ast.zig
+++ b/compiler/ast.zig
@@ -40,12 +40,17 @@ pub const WhereClause = struct {
     span: diag.Span,
 };
 
-pub const EffectKind = enum { alloc, noalloc, io, noio, panic, nopanic, custom };
+pub const EffectKind = enum { alloc, noalloc, io, noio, panic, nopanic, custom, nocustom };
 
 pub const Effect = struct {
     kind: EffectKind,
-    /// For .custom, the raw token text (without leading dot).
+    /// For .custom / .nocustom, the keyword token text without leading dot
+    /// ("custom" or "nocustom"). For other kinds, the keyword text matching
+    /// `kind` (e.g. "noalloc"). Useful for diagnostic messages.
     text: StringSlice,
+    /// For .custom("X") / .nocustom("X"), the raw user name "X" (without
+    /// surrounding quotes). Empty slice for the bare-keyword variants.
+    name: StringSlice = "",
 };
 
 pub const EffectsAttr = struct {

--- a/compiler/diagnostics.zig
+++ b/compiler/diagnostics.zig
@@ -40,6 +40,7 @@ pub const Span = struct {
 ///     Z0030 effect annotation violated by inference
 ///     Z0040 impl missing trait method(s)
 ///     Z0050 @effectsOf(f) — fn name not declared in this file
+///     Z0060 .nocustom("X") violated by inferred .custom("X")
 ///   Z01xx — parser
 ///   Z02xx — lexer
 ///   Z03xx — lower
@@ -52,6 +53,7 @@ pub const Code = enum {
     z0030_effect_violation,
     z0040_impl_missing_method,
     z0050_unknown_fn_in_effects_of,
+    z0060_custom_effect_violation,
     z0100_unexpected_token,
     z0101_expected_identifier,
     z0102_expected_token,
@@ -70,6 +72,7 @@ pub const Code = enum {
             .z0030_effect_violation => "Z0030",
             .z0040_impl_missing_method => "Z0040",
             .z0050_unknown_fn_in_effects_of => "Z0050",
+            .z0060_custom_effect_violation => "Z0060",
             .z0100_unexpected_token => "Z0100",
             .z0101_expected_identifier => "Z0101",
             .z0102_expected_token => "Z0102",
@@ -94,6 +97,7 @@ pub fn hint(code: Code) ?[]const u8 {
         .z0030_effect_violation => "the function declared an effect it then violated. Remove the `effects(...)` annotation or eliminate the disallowed operation (allocation, IO, etc.).",
         .z0040_impl_missing_method => "every method declared on the trait must be implemented. Add the listed missing methods, or drop the impl block if you do not intend to satisfy the trait.",
         .z0050_unknown_fn_in_effects_of => "@effectsOf(f) only resolves names of functions declared in the same .zpp file. Spell-check the name, declare the fn locally, or wait for cross-file inference (separate proposal).",
+        .z0060_custom_effect_violation => "the function declared `effects(.nocustom(\"X\"))` but its body (or a transitive callee) declared `effects(.custom(\"X\"))`. Drop the `.nocustom` declaration, rename the effect, or refactor the call chain so the custom effect doesn't propagate.",
         .z0100_unexpected_token => "remove or replace the highlighted token. The parser was in the middle of a declaration or expression and could not continue.",
         .z0101_expected_identifier => "supply a name here, e.g. `fn name(...)`, `struct Name { ... }`, or `const name = ...`.",
         .z0102_expected_token => "insert the expected token. Most often a missing `;`, `,`, `)`, or `}` in the surrounding scope.",
@@ -283,6 +287,27 @@ pub fn explain(code: Code) []const u8 {
         \\
         \\Fix: spell the name correctly, declare the fn in this file, or
         \\drop the `@effectsOf` query until cross-file inference lands.
+        ,
+        .z0060_custom_effect_violation =>
+        \\Z0060: .nocustom("X") declared but inferred .custom("X")
+        \\
+        \\`effects(.custom("X"))` is a user-defined effect tag. A function may
+        \\both *declare* a custom effect (asserting it for the rest of sema /
+        \\callers) and *inherit* one transitively from a same-file callee that
+        \\declares the same name. `effects(.nocustom("X"))` is the negation:
+        \\it asserts the function does NOT have effect `X`. When inference
+        \\(declaration + one round of callee propagation) disagrees with that
+        \\assertion, sema reports Z0060.
+        \\
+        \\Triggers:
+        \\    fn doIt() void effects(.custom("net")) { ... }
+        \\    fn run() void effects(.nocustom("net")) {
+        \\        doIt();   // Z0060 — caller forbids "net" but callee declares it
+        \\    }
+        \\
+        \\Fix: drop the `.nocustom("X")` declaration on the caller, rename one
+        \\of the effects, or refactor the call chain so the custom effect
+        \\doesn't reach the caller.
         ,
         .z0100_unexpected_token =>
         \\Z0100: unexpected token

--- a/compiler/parser.zig
+++ b/compiler/parser.zig
@@ -640,9 +640,28 @@ pub const Parser = struct {
                 .panic
             else if (std.mem.eql(u8, text, "nopanic"))
                 .nopanic
+            else if (std.mem.eql(u8, text, "custom"))
+                .custom
+            else if (std.mem.eql(u8, text, "nocustom"))
+                .nocustom
             else
                 .custom;
-            try list.append(self.allocator, .{ .kind = kind, .text = text });
+            // `.custom("name")` / `.nocustom("name")`: consume the
+            // parenthesised string-literal payload and store the inner
+            // name (without quotes) on the effect.
+            var name: []const u8 = "";
+            if ((kind == .custom or kind == .nocustom) and self.check(.l_paren)) {
+                _ = try self.expect(.l_paren, "custom effect (");
+                const lit = try self.expect(.string_literal, "custom effect name string");
+                const raw = lit.slice(self.source);
+                // Strip a single pair of surrounding `"` quotes if present.
+                name = if (raw.len >= 2 and raw[0] == '"' and raw[raw.len - 1] == '"')
+                    raw[1 .. raw.len - 1]
+                else
+                    raw;
+                _ = try self.expect(.r_paren, "custom effect )");
+            }
+            try list.append(self.allocator, .{ .kind = kind, .text = text, .name = name });
             if (!self.match(.comma)) break;
         }
         const close = try self.expect(.r_paren, "effects close");

--- a/compiler/sema.zig
+++ b/compiler/sema.zig
@@ -4,13 +4,21 @@ const diag = @import("diagnostics.zig");
 
 /// Per-fn effect set produced by the inference passes. Each flag is true
 /// iff sema's heuristic concluded the fn (transitively) exhibits that
-/// effect. Used by `@effectsOf(f)` lowering and by the Z0030 violation
-/// emitter.
+/// effect. Used by `@effectsOf(f)` lowering and by the Z0030/Z0060
+/// violation emitters.
 pub const InferredEffects = packed struct {
     alloc: bool = false,
     io: bool = false,
     panic: bool = false,
 };
+
+/// Per-fn list of `.custom("X")` effect names (the `X` slices, deduplicated).
+/// Sibling to the `InferredEffects` packed struct above — kept separate
+/// because the set is open-ended (each fn can carry an arbitrary number of
+/// custom names) and packing it into the struct would force a fixed cap.
+/// Slices point into the original source / AST arena and are not freed.
+pub const CustomEffectList = std.ArrayList([]const u8);
+pub const CustomEffectMap = std.StringHashMap(CustomEffectList);
 
 /// Result of semantic analysis. The maps are owned by `deinit`.
 pub const SemaResult = struct {
@@ -22,18 +30,25 @@ pub const SemaResult = struct {
     trait_methods: std.StringHashMap([]const ast.TraitMethod),
     /// Map of owned-struct names → whether they have a deinit method.
     owned_structs: std.StringHashMap(bool),
-    /// Inferred effect set per same-file fn name. Populated by the three
+    /// Inferred effect set per same-file fn name. Populated by the four
     /// `check*EffectInference` passes (each tees its result into this
     /// table at the end of the fixed-point loop). When two fns share a
     /// name (e.g. `init` on multiple structs) the first one wins — the
     /// MVP does not resolve overloads.
     inferred_effects: std.StringHashMap(InferredEffects),
+    /// Inferred `.custom("X")` effect names per same-file fn. Populated
+    /// by `checkCustomEffectInference`. Same fn-name sharing rule as
+    /// `inferred_effects`.
+    inferred_custom_effects: CustomEffectMap,
 
     pub fn deinit(self: *SemaResult) void {
         self.traits.deinit();
         self.trait_methods.deinit();
         self.owned_structs.deinit();
         self.inferred_effects.deinit();
+        var it = self.inferred_custom_effects.valueIterator();
+        while (it.next()) |list| list.deinit(self.allocator);
+        self.inferred_custom_effects.deinit();
     }
 };
 
@@ -52,6 +67,7 @@ pub const Sema = struct {
             .trait_methods = std.StringHashMap([]const ast.TraitMethod).init(self.allocator),
             .owned_structs = std.StringHashMap(bool).init(self.allocator),
             .inferred_effects = std.StringHashMap(InferredEffects).init(self.allocator),
+            .inferred_custom_effects = CustomEffectMap.init(self.allocator),
         };
         errdefer result.deinit();
 
@@ -63,6 +79,7 @@ pub const Sema = struct {
         try self.checkEffectInference(file, &result);
         try self.checkIoEffectInference(file, &result);
         try self.checkPanicEffectInference(file, &result);
+        try self.checkCustomEffectInference(file, &result);
 
         return result;
     }
@@ -951,7 +968,170 @@ pub const Sema = struct {
             }
         }
     }
+
+    /// Round 5 of the effect-inference MVP: user-defined `.custom("X")`
+    /// effects with `.nocustom("X")` as the matching denial.
+    ///
+    /// Unlike the alloc/io/panic passes (which infer effects from body
+    /// substrings), `.custom("X")` is propagated **only** from explicit
+    /// declarations. A fn carries `.custom("X")` iff
+    ///
+    ///   1. its own `effects(...)` annotation declares `.custom("X")`, OR
+    ///   2. it calls (via `<name>(`) a same-file fn whose declared
+    ///      `effects(...)` includes `.custom("X")` — propagated through
+    ///      one fixed-point loop so transitive chains are caught.
+    ///
+    /// A fn that declares `effects(.nocustom("X"))` and ends up with
+    /// `.custom("X")` in its inferred set triggers Z0060. The diagnostic
+    /// is anchored at the fn's signature span (we don't try to localise
+    /// to a body stmt — the call graph is name-only and we'd be guessing).
+    fn checkCustomEffectInference(self: *Sema, file: *const ast.File, result: *SemaResult) !void {
+        var fns: std.ArrayList(*const ast.FnDecl) = .{};
+        defer fns.deinit(self.allocator);
+        for (file.decls) |*d| {
+            switch (d.*) {
+                .fn_decl => |*fd| try fns.append(self.allocator, fd),
+                .impl_block => |ib| for (ib.fns) |*fd| try fns.append(self.allocator, fd),
+                .owned_struct => |os| for (os.fns) |*fd| try fns.append(self.allocator, fd),
+                .struct_decl => |sd| for (sd.fns) |*fd| try fns.append(self.allocator, fd),
+                else => {},
+            }
+        }
+        if (fns.items.len == 0) return;
+
+        var name_to_idx = std.StringHashMap(usize).init(self.allocator);
+        defer name_to_idx.deinit();
+        for (fns.items, 0..) |fd, i| {
+            const gop = try name_to_idx.getOrPut(fd.sig.name);
+            if (!gop.found_existing) gop.value_ptr.* = i;
+        }
+
+        const N = fns.items.len;
+
+        // Per-fn declared-custom set (the seed) and inferred-custom set
+        // (post fixed-point). Both are arrays of name slices, deduplicated.
+        const declared = try self.allocator.alloc(std.ArrayList([]const u8), N);
+        defer {
+            for (declared) |*l| l.deinit(self.allocator);
+            self.allocator.free(declared);
+        }
+        for (declared) |*l| l.* = .{};
+        const inferred = try self.allocator.alloc(std.ArrayList([]const u8), N);
+        defer {
+            for (inferred) |*l| l.deinit(self.allocator);
+            self.allocator.free(inferred);
+        }
+        for (inferred) |*l| l.* = .{};
+
+        // Per-fn local-call edges (same shape as the other passes).
+        const calls = try self.allocator.alloc(std.ArrayList(usize), N);
+        defer {
+            for (calls) |*c| c.deinit(self.allocator);
+            self.allocator.free(calls);
+        }
+        for (calls) |*c| c.* = .{};
+
+        // Seed: collect each fn's declared `.custom("X")` names and record
+        // the body's local-fn callee edges. `.nocustom(...)` is NOT seeded
+        // — it's purely a denial (checked at the end against the inferred
+        // set).
+        for (fns.items, 0..) |fd, i| {
+            if (fd.sig.effects) |ef| {
+                for (ef.effects) |e| {
+                    if (e.kind == .custom and e.name.len > 0) {
+                        _ = try addUniqueName(&declared[i], self.allocator, e.name);
+                        _ = try addUniqueName(&inferred[i], self.allocator, e.name);
+                    }
+                }
+            }
+            const body = fd.body orelse continue;
+            for (body.stmts) |s| {
+                const text = switch (s) {
+                    .raw => |r| r.text,
+                    .using_stmt => |u| u.init_text,
+                    .own_decl => |o| o.init_text,
+                    else => continue,
+                };
+                try collectLocalCalls(text, &name_to_idx, &calls[i], self.allocator);
+            }
+        }
+
+        // Fixed-point: a fn inherits every `.custom("X")` declared by any
+        // fn it calls. Propagation reads from `declared` (the explicit
+        // annotation set) so a chain A→B→C with C declaring `.custom("X")`
+        // still flows up to A. Cap at N+1 rounds; in practice converges in
+        // one or two passes.
+        var changed = true;
+        var rounds: usize = 0;
+        while (changed and rounds < N + 1) : (rounds += 1) {
+            changed = false;
+            for (fns.items, 0..) |_, i| {
+                for (calls[i].items) |cid| {
+                    for (declared[cid].items) |name| {
+                        if (try addUniqueName(&inferred[i], self.allocator, name)) {
+                            changed = true;
+                        }
+                    }
+                    // Also propagate already-inferred names from the callee
+                    // so transitive chains converge in fewer rounds.
+                    for (inferred[cid].items) |name| {
+                        if (try addUniqueName(&inferred[i], self.allocator, name)) {
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Tee inferred custom-effect names into the result table so
+        // `@effectsOf(<ident>)` lowering can render them.
+        for (fns.items, 0..) |fd, i| {
+            if (inferred[i].items.len == 0) continue;
+            const gop = try result.inferred_custom_effects.getOrPut(fd.sig.name);
+            if (!gop.found_existing) gop.value_ptr.* = .{};
+            for (inferred[i].items) |name| {
+                _ = try addUniqueName(gop.value_ptr, self.allocator, name);
+            }
+        }
+
+        // Z0060: emit on every (fn, X) pair where the fn declares
+        // `.nocustom("X")` and the inferred set contains `.custom("X")`.
+        for (fns.items, 0..) |fd, i| {
+            const ef = fd.sig.effects orelse continue;
+            for (ef.effects) |e| {
+                if (e.kind != .nocustom) continue;
+                if (e.name.len == 0) continue;
+                var present = false;
+                for (inferred[i].items) |n| {
+                    if (std.mem.eql(u8, n, e.name)) { present = true; break; }
+                }
+                if (!present) continue;
+                try self.diags.emit(
+                    .err,
+                    .z0060_custom_effect_violation,
+                    fd.sig.span,
+                    "fn '{s}' declared .nocustom(\"{s}\") but inferred .custom(\"{s}\") effect",
+                    .{ fd.sig.name, e.name, e.name },
+                );
+            }
+        }
+    }
 };
+
+/// Append `name` to `list` if it isn't already present (string comparison).
+/// Returns true when an insertion occurred. Slices stored verbatim — they
+/// reference source / AST arena memory that outlives this pass.
+fn addUniqueName(
+    list: *std.ArrayList([]const u8),
+    allocator: std.mem.Allocator,
+    name: []const u8,
+) !bool {
+    for (list.items) |existing| {
+        if (std.mem.eql(u8, existing, name)) return false;
+    }
+    try list.append(allocator, name);
+    return true;
+}
 
 /// Heuristic: does `text` look like an allocator-using call? We check for
 /// identifiers containing "alloc"/"init"/"create" near a token that resembles

--- a/docs/src/v0.2-plan.md
+++ b/docs/src/v0.2-plan.md
@@ -297,8 +297,32 @@ in a sema-built table — synthesising it textually keeps the
 parser surface small (no new AST variant, no new token) and
 matches the pattern already used by `@import` rewriting.
 
+Done (round 5: `.custom("name")` user-defined effects):
+- `compiler/ast.zig`: `EffectKind` gained `.nocustom`. The
+  `Effect` struct already carries a `name: []const u8` slot for
+  the user-supplied effect name (e.g. `"net"`).
+- `compiler/parser.zig`: recognises `effects(.custom("X"))` and
+  `effects(.nocustom("X"))` — consumes the parenthesised string
+  literal after the keyword.
+- `compiler/sema.zig`: new `checkCustomEffectInference` pass.
+  Each fn collects its declared `.custom("X")` names and
+  propagates one round through same-file callees: caller A
+  inherits `.custom("X")` if any callee declares it. Compared
+  against `.nocustom("X")` annotations: violation emits Z0060.
+- `compiler/diagnostics.zig`: new code Z0060
+  (`z0060_custom_effect_violation`) — fires when a fn declares
+  `.nocustom("X")` but inference (declaration + transitive
+  propagation) places `.custom("X")` in its set.
+- `tests/diagnostics/diags.zig`: positive (`.custom("net")`
+  matches inference, no Z0060) and negative (`.nocustom("net")`
+  violated by transitive callee fires Z0060) tests added.
+- `@effectsOf(f)` integration with `.custom` is intentionally
+  deferred — the lowering still emits only the alloc/io/panic
+  axes, so a fn whose only effect is `.custom("X")` lowers to `""`.
+
 Still TODO:
-- Inference for `.custom` effect kinds.
+- Surface `.custom("X")` names in `@effectsOf(f)` output (extend
+  the lowerer's substitution to include `custom("X")` entries).
 - Cross-file effect propagation. Today only fns declared in the
   same file are considered when propagating; a `.noalloc` fn that
   calls into an imported allocating fn is silently accepted.

--- a/tests/diagnostics/diags.zig
+++ b/tests/diagnostics/diags.zig
@@ -347,3 +347,51 @@ test "Z0050: @effectsOf of an unknown fn fires and lowers to empty" {
     try std.testing.expect(std.mem.indexOf(u8, out, "return \"\";") != null);
     try std.testing.expect(hasCode(&diags, "Z0050"));
 }
+
+// --- Z0060 .custom("name") effect inference (round 5) ---
+
+test "Z0060: nocustom matches declared custom does not fire" {
+    // `caller` declares effects(.custom("net")) and calls `worker` which
+    // also declares effects(.custom("net")). Inference agrees with the
+    // declaration; no Z0060.
+    const a = std.testing.allocator;
+    const src =
+        \\effects(.custom("net")) fn worker() void {}
+        \\effects(.custom("net")) fn caller() void { worker(); }
+    ;
+    var result = try analyze(a, src);
+    defer result.diags.deinit();
+    try std.testing.expect(!hasCode(&result.diags, "Z0060"));
+}
+
+test "Z0060: nocustom violated by transitive custom callee fires" {
+    // `caller` declares .nocustom("net") but calls `worker` which declares
+    // .custom("net"). Inference propagates .custom("net") up to caller,
+    // contradicting the .nocustom annotation, so Z0060 must fire on caller.
+    const a = std.testing.allocator;
+    const src =
+        \\effects(.custom("net")) fn worker() void {}
+        \\effects(.nocustom("net")) fn caller() void { worker(); }
+    ;
+    var result = try analyze(a, src);
+    defer result.diags.deinit();
+    try std.testing.expect(hasCode(&result.diags, "Z0060"));
+}
+
+test "Z0050: @effectsOf still resolves a custom-effect-only fn (lowering MVP omits the name)" {
+    // Lowering for @effectsOf currently only emits the alloc/io/panic axes
+    // (round 4 shape). A fn whose only effect is `.custom("net")` therefore
+    // lowers to "" — no Z0050 — and emitting custom names through @effectsOf
+    // is left as a follow-up.
+    const a = std.testing.allocator;
+    var diags = compiler.Diagnostics.init(a);
+    defer diags.deinit();
+    const src =
+        \\effects(.custom("net")) fn worker() void {}
+        \\fn ask() []const u8 { return @effectsOf(worker); }
+    ;
+    const out = try compiler.compileToZig(a, src, &diags);
+    defer a.free(out);
+    try std.testing.expect(!hasCode(&diags, "Z0050"));
+    try std.testing.expect(std.mem.indexOf(u8, out, "return \"\";") != null);
+}


### PR DESCRIPTION
## Summary
Adds user-defined effects to the inference pipeline. A fn can now declare
\`effects(.custom("net"))\` or \`effects(.nocustom("net"))\`, and sema
checks that \`.nocustom("X")\` callers don't transitively pull in
\`.custom("X")\` callees.

## Algorithm
1. **AST/parser**: \`EffectKind.nocustom\` joins the existing \`.custom\`. Parser consumes the parenthesised string literal after each keyword.
2. **Sema**: \`checkCustomEffectInference\` collects declared \`.custom("X")\` names per fn, then propagates one round through same-file callees. A fn declaring \`.nocustom("X")\` whose inferred set then contains \`.custom("X")\` emits Z0060.
3. **Diagnostic**: Z0060 \`z0060_custom_effect_violation\` (Z0030 covers .alloc/.io/.panic; Z0060 is the .custom-specific code so messages can be specific).

## What lands
- 3 new files in \`compiler/\` get small additions
- 1 new diagnostic code (Z0060)
- 3 new tests in \`tests/diagnostics/diags.zig\`
- v0.2 plan gains a "Done (round 5)" subsection

## Out of scope (follow-ups)
- Surfacing \`.custom("X")\` names through \`@effectsOf(f)\` output (today the lowering only includes alloc/io/panic axes; a fn whose only effect is \`.custom("X")\` lowers to \`""\`).
- Cross-file \`.custom\` effect propagation.

## Test plan
- [x] \`zig build test\` (3 new tests; existing tests unchanged)
- [x] \`zig build all\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)