### PR TITLE
feat(sema): @effectsOf surfaces .custom("name") in lowered output

### DIFF
--- a/compiler/lower_to_zig.zig
+++ b/compiler/lower_to_zig.zig
@@ -7,6 +7,12 @@ const sema = @import("sema.zig");
 /// generic type. Owned by the caller (typically a `SemaResult`).
 pub const InferredEffectsMap = std.StringHashMap(sema.InferredEffects);
 
+/// Sibling alias for the per-fn `.custom("X")` name table that the
+/// `@effectsOf(<ident>)` lowering also consults. Owned by the caller
+/// (typically a `SemaResult`); each value is a list of name slices that
+/// reference the original source / AST arena and must outlive lowering.
+pub const InferredCustomEffectsMap = sema.CustomEffectMap;
+
 /// Lowering pass: walks an `ast.File` and produces a Zig source string.
 ///
 /// The lowering is intentionally textual: identifiers and types are kept as
@@ -28,6 +34,12 @@ pub const Lowerer = struct {
     /// sema entirely. When null, `@effectsOf(<ident>)` lowers to `""`
     /// and Z0050 is suppressed (we have no table to check against).
     inferred_effects: ?*const InferredEffectsMap = null,
+    /// Per-fn inferred `.custom("X")` name set, supplied by sema.
+    /// Sibling to `inferred_effects`; appended after the alloc/io/panic
+    /// axes so the lowered string keeps backwards compatibility (a fn
+    /// with no custom effects produces the exact same shape as before).
+    /// Optional for the same reasons as `inferred_effects`.
+    inferred_custom: ?*const InferredCustomEffectsMap = null,
 
     pub fn init(allocator: std.mem.Allocator, diags: *diag.Diagnostics) Lowerer {
         return .{
@@ -38,6 +50,7 @@ pub const Lowerer = struct {
             .extern_traits = std.StringHashMap(void).init(allocator),
             .impls_by_target = std.StringHashMap(std.ArrayList(*const ast.ImplBlock)).init(allocator),
             .inferred_effects = null,
+            .inferred_custom = null,
         };
     }
 
@@ -51,6 +64,21 @@ pub const Lowerer = struct {
     ) Lowerer {
         var lw = init(allocator, diags);
         lw.inferred_effects = effects;
+        return lw;
+    }
+
+    /// Same as `initWithEffects` but also wires the per-fn `.custom("X")`
+    /// table so the `@effectsOf(<ident>)` substitution can append the
+    /// `custom("X")` entries after the alloc/io/panic axes. Pass the map
+    /// straight from `sema.SemaResult.inferred_custom_effects`.
+    pub fn initWithEffectsAndCustom(
+        allocator: std.mem.Allocator,
+        diags: *diag.Diagnostics,
+        effects: *const InferredEffectsMap,
+        custom: *const InferredCustomEffectsMap,
+    ) Lowerer {
+        var lw = initWithEffects(allocator, diags, effects);
+        lw.inferred_custom = custom;
         return lw;
     }
 
@@ -449,6 +477,22 @@ pub const Lowerer = struct {
             try self.write("panic");
             first = false;
         }
+        // Append `custom("X")` entries (if any) after the alloc/io/panic
+        // axes. The order matches the sibling map's insertion order so
+        // the lowered string stays stable across runs. The leading axes
+        // are unchanged when no custom effects are present, which keeps
+        // the output backwards-compatible with round-4 lowering.
+        if (self.inferred_custom) |cmap| {
+            if (cmap.get(ident)) |list| {
+                for (list.items) |name| {
+                    if (!first) try self.write(",");
+                    try self.write("custom(\\\"");
+                    try self.write(name);
+                    try self.write("\\\")");
+                    first = false;
+                }
+            }
+        }
         try self.write("\"");
     }
 
@@ -753,6 +797,21 @@ pub fn lowerWithEffects(
     return lw.lowerFile(file);
 }
 
+/// Same as `lowerWithEffects` but also wires the per-fn `.custom("X")`
+/// table so `@effectsOf(<ident>)` substitutions can append the
+/// `custom("X")` entries after the alloc/io/panic axes.
+pub fn lowerWithEffectsAndCustom(
+    allocator: std.mem.Allocator,
+    file: *const ast.File,
+    diags: *diag.Diagnostics,
+    effects: *const InferredEffectsMap,
+    custom: *const InferredCustomEffectsMap,
+) ![]u8 {
+    var lw = Lowerer.initWithEffectsAndCustom(allocator, diags, effects, custom);
+    defer lw.deinit();
+    return lw.lowerFile(file);
+}
+
 test "lower using stmt" {
     const a = std.testing.allocator;
     const parser = @import("parser.zig");
@@ -838,4 +897,49 @@ test "lower @effectsOf substitutes the inferred string" {
     defer a.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "return \"\";") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "return \"alloc,io\";") != null);
+}
+
+test "lower @effectsOf appends custom names after alloc/io/panic axes" {
+    // Direct unit test of the round-5 follow-up: when a fn has an
+    // inferred `.custom("X")` set, the substitution appends
+    // `custom("X")` entries after the alloc/io/panic axes (with the
+    // `"` doubly-escaped because the rewrite is itself emitted inside
+    // a Zig string literal). Mirrors the end-to-end coverage in
+    // tests/diagnostics/diags.zig.
+    const a = std.testing.allocator;
+    const parser = @import("parser.zig");
+    var diags = diag.Diagnostics.init(a);
+    defer diags.deinit();
+    var arena = ast.Arena.init(a);
+    defer arena.deinit();
+
+    var effects = InferredEffectsMap.init(a);
+    defer effects.deinit();
+    try effects.put("net_only", .{});
+    try effects.put("alloc_and_net", .{ .alloc = true });
+
+    var custom = InferredCustomEffectsMap.init(a);
+    defer {
+        var it = custom.valueIterator();
+        while (it.next()) |list| list.deinit(a);
+        custom.deinit();
+    }
+    var net_only_list: sema.CustomEffectList = .{};
+    try net_only_list.append(a, "net");
+    try custom.put("net_only", net_only_list);
+    var combo_list: sema.CustomEffectList = .{};
+    try combo_list.append(a, "net");
+    try custom.put("alloc_and_net", combo_list);
+
+    const src =
+        \\fn net_only() void {}
+        \\fn alloc_and_net() void {}
+        \\fn ask() []const u8 { return @effectsOf(net_only); }
+        \\fn ask2() []const u8 { return @effectsOf(alloc_and_net); }
+    ;
+    const file = try parser.parseSource(a, src, &arena, &diags);
+    const out = try lowerWithEffectsAndCustom(a, &file, &diags, &effects, &custom);
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "return \"custom(\\\"net\\\")\";") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "return \"alloc,custom(\\\"net\\\")\";") != null);
 }

--- a/compiler/mod.zig
+++ b/compiler/mod.zig
@@ -35,8 +35,10 @@ pub const SemaResult = sema.SemaResult;
 pub const Lowerer = lower_to_zig.Lowerer;
 pub const lower = lower_to_zig.lower;
 pub const lowerWithEffects = lower_to_zig.lowerWithEffects;
+pub const lowerWithEffectsAndCustom = lower_to_zig.lowerWithEffectsAndCustom;
 pub const InferredEffects = sema.InferredEffects;
 pub const InferredEffectsMap = lower_to_zig.InferredEffectsMap;
+pub const InferredCustomEffectsMap = lower_to_zig.InferredCustomEffectsMap;
 
 pub const locate = diagnostics.locate;
 
@@ -93,10 +95,18 @@ pub fn compileToZig(
     var s = sema.Sema.init(allocator, diags);
     var res = try s.analyze(&file);
     defer res.deinit();
-    // Pass the per-fn inferred-effect table into the lowerer so
-    // `@effectsOf(<ident>)` substitutions can resolve. Z0050 is emitted
-    // for unknown names on the lowering side via this table.
-    return lower_to_zig.lowerWithEffects(allocator, &file, diags, &res.inferred_effects);
+    // Pass the per-fn inferred-effect tables (axes + custom names) into
+    // the lowerer so `@effectsOf(<ident>)` substitutions can resolve.
+    // Z0050 is emitted for unknown names on the lowering side via the
+    // axes table; the custom table is consulted for the optional
+    // `custom("X")` suffix entries.
+    return lower_to_zig.lowerWithEffectsAndCustom(
+        allocator,
+        &file,
+        diags,
+        &res.inferred_effects,
+        &res.inferred_custom_effects,
+    );
 }
 
 test "end-to-end compile sample" {

--- a/docs/src/v0.2-plan.md
+++ b/docs/src/v0.2-plan.md
@@ -319,10 +319,27 @@ Done (round 5: `.custom("name")` user-defined effects):
 - `@effectsOf(f)` integration with `.custom` is intentionally
   deferred — the lowering still emits only the alloc/io/panic
   axes, so a fn whose only effect is `.custom("X")` lowers to `""`.
+  *(Superseded — see "Done (round 5 follow-up)" below.)*
+
+Done (round 5 follow-up: `.custom("X")` in `@effectsOf(f)`):
+- `compiler/lower_to_zig.zig`: `Lowerer` gained an optional
+  `inferred_custom` field plus `initWithEffectsAndCustom` /
+  `lowerWithEffectsAndCustom` entry points. `writeEffectsOfFor`
+  appends each `.custom("X")` name as `custom("X")` after the
+  alloc/io/panic axes (with `"` escaped because the substitution
+  itself sits inside a Zig string literal). Fns with no custom
+  effects produce the same shape as before — backwards-compatible
+  with round-4 lowering.
+- `compiler/mod.zig`: `compileToZig` plumbs both the alloc/io/panic
+  table and the `.custom("X")` table through to the lowerer.
+- `tests/diagnostics/diags.zig`: the prior "lowering MVP omits the
+  name" assertion is flipped to expect `"custom(\"net\")"`, and a
+  new combo test covers `"alloc,custom(\"net\")"` for fns that both
+  allocate and declare `.custom("net")`.
+- `examples/effects_of.zpp`: gained a `networking` fn with
+  `.custom("net")` and a third `@effectsOf` print line.
 
 Still TODO:
-- Surface `.custom("X")` names in `@effectsOf(f)` output (extend
-  the lowerer's substitution to include `custom("X")` entries).
 - Cross-file effect propagation. Today only fns declared in the
   same file are considered when propagating; a `.noalloc` fn that
   calls into an imported allocating fn is silently accepted.

--- a/examples/effects_of.zpp
+++ b/examples/effects_of.zpp
@@ -1,7 +1,7 @@
 /// effects_of.zpp — `@effectsOf(f)` queryable surface.
 ///
 /// Teaches: every same-file fn has an inferred effect set computed by
-/// sema's three inference passes (alloc / io / panic). The
+/// sema's four inference passes (alloc / io / panic / custom). The
 /// `@effectsOf(f)` builtin surfaces that set as a comma-separated
 /// `[]const u8` you can read at comptime (or at runtime, since the
 /// substitution is just a string literal). Useful for programmatic
@@ -12,9 +12,10 @@
 ///     // each `@effectsOf(<ident>)` becomes a `[]const u8` literal
 ///     // synthesised at lowering time. Pure fns produce `""`; fns
 ///     // that allocate produce `"alloc"`; combinations are joined
-///     // with `,` in a fixed order (alloc, io, panic).
+///     // with `,` in a fixed order (alloc, io, panic, custom("X")...).
 ///     std.debug.print("pure -> {s}\n", .{""});
 ///     std.debug.print("noisy -> {s}\n", .{"alloc,io"});
+///     std.debug.print("networking -> {s}\n", .{"custom(\"net\")"});
 
 const std = @import("std");
 const zpp = @import("zpp");
@@ -32,23 +33,36 @@ fn noisy(a: std.mem.Allocator) !void {
     std.debug.print("noisy: allocated {d} bytes\n", .{buf.len});
 }
 
+effects(.custom("net")) fn networking() void {
+    // No body content needed — the `.custom("net")` annotation alone
+    // seeds the inferred set so `@effectsOf(networking)` lowers to
+    // `"custom(\"net\")"`. Useful for tagging fns that talk to the
+    // network without wiring a full sema heuristic.
+}
+
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    // The two literals below are produced by the lowerer at compile
-    // time — `@effectsOf(pure)` becomes the literal `""`, and
-    // `@effectsOf(noisy)` becomes `"alloc,io"`. No runtime work is
-    // performed to compute them.
+    // The three literals below are produced by the lowerer at compile
+    // time — `@effectsOf(pure)` becomes the literal `""`,
+    // `@effectsOf(noisy)` becomes `"alloc,io"`, and
+    // `@effectsOf(networking)` becomes `"custom(\"net\")"`. No runtime
+    // work is performed to compute them.
     const pure_effects: []const u8 = @effectsOf(pure);
     const noisy_effects: []const u8 = @effectsOf(noisy);
+    const net_effects: []const u8 = @effectsOf(networking);
 
-    std.debug.print("@effectsOf(pure)  = \"{s}\"\n", .{pure_effects});
-    std.debug.print("@effectsOf(noisy) = \"{s}\"\n", .{noisy_effects});
+    std.debug.print("@effectsOf(pure)       = \"{s}\"\n", .{pure_effects});
+    std.debug.print("@effectsOf(noisy)      = \"{s}\"\n", .{noisy_effects});
+    std.debug.print("@effectsOf(networking) = \"{s}\"\n", .{net_effects});
 
     // Drive `noisy` once so the allocator path is actually exercised.
     try noisy(allocator);
+
+    // Drive `networking` once so the call is observable in the binary.
+    networking();
 
     // Use `pure` so the compiler doesn't strip it.
     std.debug.print("pure(7) = {x}\n", .{pure(7)});

--- a/tests/diagnostics/diags.zig
+++ b/tests/diagnostics/diags.zig
@@ -378,11 +378,13 @@ test "Z0060: nocustom violated by transitive custom callee fires" {
     try std.testing.expect(hasCode(&result.diags, "Z0060"));
 }
 
-test "Z0050: @effectsOf still resolves a custom-effect-only fn (lowering MVP omits the name)" {
-    // Lowering for @effectsOf currently only emits the alloc/io/panic axes
-    // (round 4 shape). A fn whose only effect is `.custom("net")` therefore
-    // lowers to "" — no Z0050 — and emitting custom names through @effectsOf
-    // is left as a follow-up.
+test "@effectsOf surfaces a custom-effect-only fn as custom(\"net\")" {
+    // Round-5 follow-up: `@effectsOf(<ident>)` now appends each
+    // inferred `.custom("X")` name after the alloc/io/panic axes.
+    // A fn whose only effect is `.custom("net")` therefore lowers to
+    // `"custom(\"net\")"` (the inner `"` is escaped because the
+    // substitution itself sits inside a Zig double-quoted string
+    // literal). No Z0050 fires — sema knows about the fn.
     const a = std.testing.allocator;
     var diags = compiler.Diagnostics.init(a);
     defer diags.deinit();
@@ -393,5 +395,27 @@ test "Z0050: @effectsOf still resolves a custom-effect-only fn (lowering MVP omi
     const out = try compiler.compileToZig(a, src, &diags);
     defer a.free(out);
     try std.testing.expect(!hasCode(&diags, "Z0050"));
-    try std.testing.expect(std.mem.indexOf(u8, out, "return \"\";") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "return \"custom(\\\"net\\\")\";") != null);
+}
+
+test "@effectsOf appends custom(\"net\") after alloc when both are inferred" {
+    // A fn that both allocates AND declares `.custom("net")` lowers to
+    // `"alloc,custom(\"net\")"` — the custom entries trail the
+    // alloc/io/panic axes so existing consumers that only inspect the
+    // axes prefix keep working unchanged.
+    const a = std.testing.allocator;
+    var diags = compiler.Diagnostics.init(a);
+    defer diags.deinit();
+    const src =
+        \\const std = @import("std");
+        \\effects(.custom("net")) fn worker(al: std.mem.Allocator) !void {
+        \\    const xs = try al.alloc(u8, 1);
+        \\    _ = xs;
+        \\}
+        \\fn ask() []const u8 { return @effectsOf(worker); }
+    ;
+    const out = try compiler.compileToZig(a, src, &diags);
+    defer a.free(out);
+    try std.testing.expect(!hasCode(&diags, "Z0050"));
+    try std.testing.expect(std.mem.indexOf(u8, out, "return \"alloc,custom(\\\"net\\\")\";") != null);
 }


### PR DESCRIPTION
## Summary

Closes the round-5 follow-up TODO in `docs/src/v0.2-plan.md`. The `@effectsOf(<ident>)` lowering now appends each inferred `.custom("X")` name as `custom("X")` after the existing alloc/io/panic axes.

- New `Lowerer.inferred_custom` field + `initWithEffectsAndCustom` / `lowerWithEffectsAndCustom` entry points; `compileToZig` plumbs `SemaResult.inferred_custom_effects` through.
- `writeEffectsOfFor` appends `,custom("X")` per inferred name (escaping the inner `"` because the substitution sits inside a Zig string literal). Insertion order from sema is preserved.
- Backwards compatible: fns with no custom effects produce the exact same string shape as before.

### Before / after

`effects(.custom("net")) fn worker() void {}`

| call site | before | after |
|---|---|---|
| `@effectsOf(worker)` (custom only) | `""` | `"custom(\"net\")"` |
| `@effectsOf(allocAndNet)` (`.alloc` + `.custom("net")`) | `"alloc"` | `"alloc,custom(\"net\")"` |
| `@effectsOf(pure)` (no effects) | `""` | `""` (unchanged) |
| `@effectsOf(allocOnly)` (`.alloc` only) | `"alloc"` | `"alloc"` (unchanged) |

### Files changed

- `compiler/lower_to_zig.zig` — new `inferred_custom` field, `initWithEffectsAndCustom`, `lowerWithEffectsAndCustom`, extended `writeEffectsOfFor`, new direct unit test.
- `compiler/mod.zig` — re-exports `lowerWithEffectsAndCustom` / `InferredCustomEffectsMap`; `compileToZig` plumbs both tables.
- `tests/diagnostics/diags.zig` — flipped Z0050 custom-only-fn assertion to expect `"custom(\"net\")"`; added combo test for `"alloc,custom(\"net\")"`.
- `examples/effects_of.zpp` — added a `networking` fn with `.custom("net")` and a third `@effectsOf` print line.
- `docs/src/v0.2-plan.md` — removed the "Surface .custom("X") names in @effectsOf(f) output" item from "Still TODO"; added a "Done (round 5 follow-up)" subsection.

## Test plan

- [x] `zig build test` exits 0.
- [x] `zig build all` exits 0; `examples/effects_of.zpp` prints `@effectsOf(networking) = "custom("net")"` at runtime.
- [x] Backwards compatibility verified — existing `@effectsOf(pure) lowers to empty string` and `@effectsOf(allocOnly) lowers to "alloc"` tests still pass unchanged.

## Out of scope

- Cross-file `.custom` propagation.
- Set algebra on `.custom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)