### PR TITLE
fix(tests): audit handles Windows path separators

### DIFF
--- a/tests/no_hidden_alloc/audit.zig
+++ b/tests/no_hidden_alloc/audit.zig
@@ -35,8 +35,16 @@ fn auditTree(allocator: std.mem.Allocator, root: []const u8, offenders: *std.Arr
         if (entry.kind != .file) continue;
         if (!std.mem.endsWith(u8, entry.path, ".zig")) continue;
 
-        const rel = try std.fs.path.join(allocator, &.{ root, entry.path });
+        // Force forward-slash join so the comparison against
+        // `allowed_main_entries` (which uses `/`) works on Windows too,
+        // where `std.fs.path.join` would emit `\` separators.
+        const rel = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ root, entry.path });
         defer allocator.free(rel);
+        // Normalise any embedded backslashes from `entry.path` on Windows
+        // hosts that traverse into subdirectories.
+        for (rel) |*c| if (c.* == '\\') {
+            c.* = '/';
+        };
 
         if (isAllowed(rel)) continue;
 


### PR DESCRIPTION
## Summary
PR #84 added a code-action test fixture in \`tools/zpp_lsp.zig\` containing the literal text \`std.heap.page_allocator\` (inside a Zig source string used as test input). The \`no_hidden_alloc\` audit scans for that needle and exempts the 5 CLI mains via path comparison.

On Windows the audit failed because \`std.fs.path.join\` emits the relative path as \`tools\\zpp_lsp.zig\`, which never matches the allow-list entry \`tools/zpp_lsp.zig\`. Result: a Windows-only CI red.

## Fix
Use \`std.fmt.allocPrint(\"{s}/{s}\")\` for the join and normalise any embedded backslashes that \`walker.next()\` returns on Windows. The allow-list works on every platform now.

## Test plan
- [x] \`zig build test\` (passes locally on macOS)
- [x] CI Windows build will confirm the fix on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)