### PR TITLE
chore(build): fix `zig build --help` step descriptions

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -69,7 +69,7 @@ pub fn build(b: *std.Build) void {
         run_step.dependOn(&run_cmd.step);
     }
 
-    const test_step = b.step("test", "Run unit tests for compiler/, lib/, tools/");
+    const test_step = b.step("test", "Run unit tests for compiler/, lib/, tools/, tests/");
     addTestsForTree(b, target, optimize, zpp_module, zpp_compiler_module, "compiler", test_step);
     addTestsForTree(b, target, optimize, zpp_module, zpp_compiler_module, "lib", test_step);
     addTestsForTree(b, target, optimize, zpp_module, zpp_compiler_module, "tools", test_step);
@@ -83,7 +83,7 @@ pub fn build(b: *std.Build) void {
         check_step.dependOn(&check_cmd.step);
     }
 
-    const examples_step = b.step("examples", "Lower and build every .zpp under examples/");
+    const examples_step = b.step("examples", "Lower every .zpp under examples/ to .zig (no execution)");
     if (main_exe) |exe| {
         addExampleSteps(b, exe, examples_step);
     }


### PR DESCRIPTION
## Summary

Two step descriptions in `build.zig` drifted from what the code actually runs (and from what `README.md` documents). One-line fix per step, no behavior change.

## What's in this PR

### 1. `test` step lists which trees actually run

`build.zig:72` declared:

```zig
const test_step = b.step("test", "Run unit tests for compiler/, lib/, tools/");
```

…but lines 73–76 also call `addTestsForTree(..., "tests", test_step)`. So `zig build test` does walk `tests/`, the description just didn't say so.

```diff
- const test_step = b.step("test", "Run unit tests for compiler/, lib/, tools/");
+ const test_step = b.step("test", "Run unit tests for compiler/, lib/, tools/, tests/");
```

### 2. `examples` step description matches what the step actually does

`addExampleSteps` issues `zpp lower <path>` only — it does **not** build the lowered `.zig`. `README.md` documents this step as:

> `zig build examples           # lower every .zpp example to .zig (no execution)`

…but `build.zig:86` said `"Lower and build every .zpp under examples/"`, which contradicts both the implementation (no build) and the README. Building the lowered output is what the separate `e2e` step is for.

```diff
- const examples_step = b.step("examples", "Lower and build every .zpp under examples/");
+ const examples_step = b.step("examples", "Lower every .zpp under examples/ to .zig (no execution)");
```

## Test plan

- [x] `zig build --help` renders the new descriptions correctly:
  ```
  test       Run unit tests for compiler/, lib/, tools/, tests/
  examples   Lower every .zpp under examples/ to .zig (no execution)
  ```
- [x] No source semantics changed — only string literals passed to `b.step(...)`.
- [x] `git diff` is 2 lines, single file (`build.zig`).

## Notes

Found while auditing the build graph for help-text drift; no behavior change, so `e2e` / `examples` / `test` execution is unaffected and snapshot/fuzz steps are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)