### PR TITLE
chore: typo and consistency fixes across compiler, lib, and CLI

### DIFF
--- a/compiler/diagnostics.zig
+++ b/compiler/diagnostics.zig
@@ -150,14 +150,14 @@ pub fn explain(code: Code) []const u8 {
         \\anything that needs releasing.
         ,
         .z0011_using_type_lacks_deinit =>
-        \\Z0011: `using` target has no deinit
+        \\Z0011: `using` target lacks deinit
         \\
         \\`using x = expr;` lowers to `var x = expr; defer x.deinit();`. The
         \\type of `expr` must therefore have a `deinit` method, otherwise the
         \\generated `defer` would not type-check.
         \\
         \\Triggers:
-        \\    using s = "literal";   // []const u8 has no deinit
+        \\    using s = "literal";   // []const u8 lacks deinit
         \\
         \\Fix:
         \\    var s: []const u8 = "literal";   // plain var, no auto-cleanup

--- a/lib/writer.zig
+++ b/lib/writer.zig
@@ -155,7 +155,7 @@ pub const StdoutWriter = struct {
     }
 
     /// Build a `Writer` fat pointer from a `*StdoutWriter`. The vtable is
-    /// materialised once at comptime and stored as a `static const`.
+    /// materialized once at comptime and stored as a `static const`.
     pub fn writer(self: *StdoutWriter) Writer {
         return dyn.fromImpl(Writer_VTable, StdoutWriter, self, .{
             .{ "write", StdoutWriter.write },

--- a/tools/zpp.zig
+++ b/tools/zpp.zig
@@ -178,7 +178,7 @@ fn cmdHelp(args: [][:0]u8) !ExitCode {
         .run => "zpp run <file.zpp>\n  Lower a single .zpp source, write it to a tmp file, and execute it via `zig run`.\n",
         .lower => "zpp lower <file.zpp>\n  Print lowered .zig source for one file to stdout.\n",
         .fmt => "zpp fmt [paths...]\n  Re-emit .zpp files with canonical whitespace; expands directories.\n",
-        .check => "zpp check [paths...]\n  Parse and semantically analyse .zpp files; emit diagnostics; exit 1 on error.\n",
+        .check => "zpp check [paths...]\n  Parse and semantically analyze .zpp files; emit diagnostics; exit 1 on error.\n",
         .watch => "zpp watch [paths...]\n  Snapshot .zpp file mtimes and re-run `zpp check` whenever any of them changes. Polls every ~500ms; Ctrl-C to exit.\n",
         .doc => "zpp doc [paths...]\n  Walk .zpp files and emit Markdown for trait/fn/struct/extern interface decls.\n",
         .migrate => "zpp migrate <file.zig>\n  Diff suggestions to convert defer/init/deinit patterns to Zig++.\n",

--- a/tools/zpp_fmt.zig
+++ b/tools/zpp_fmt.zig
@@ -6,7 +6,7 @@ pub const FormatOptions = struct {
 
 const indent_unit: []const u8 = "    ";
 
-/// Recognised Zig++ keywords that should always be followed by a space.
+/// Recognized Zig++ keywords that should always be followed by a space.
 const zpp_keywords = [_][]const u8{
     "trait",      "impl",     "dyn",       "using",
     "owned",      "own",      "move",      "where",
@@ -341,7 +341,7 @@ pub fn main() !void {
         if (std.mem.eql(u8, a, "--check")) {
             opts.check_only = true;
         } else if (std.mem.eql(u8, a, "--help") or std.mem.eql(u8, a, "-h")) {
-            try emitError("zpp-fmt [--check] [paths...]\n", .{});
+            try emitError("zpp fmt [--check] [paths...]\n", .{});
             return;
         } else {
             try paths.append(allocator, a);


### PR DESCRIPTION
## Summary

Small set of high-confidence textual fixes surfaced by an audit of comments, doc strings, and CLI help text. All changes are surface-level: no behavior change, no public API change.

- **compiler/diagnostics.zig** — `zpp explain Z0011` now says "lacks deinit", matching the inline summary at line 37 (was "has no deinit"). The runtime sema diagnostic message is unchanged, so existing snapshot tests are unaffected.
- **lib/writer.zig** — spell "materialized" consistently with `lib/dyn.zig` (was "materialised").
- **tools/zpp.zig** — `zpp check` help text says "analyze" to match the dominant spelling across the codebase (`sema.zig`, `mod.zig`, `zpp_lsp.zig` all use `analyze`).
- **tools/zpp_fmt.zig** — `--help` usage line spells the subcommand `zpp fmt` to match every other subcommand's help format (was `zpp-fmt`); doc comment says "Recognized" to match the rest of the codebase.

## Test plan

- [x] `zig build` — clean
- [x] `zig build check` — clean
- [x] `grep` confirmed no test snapshots reference the changed Z0011 explanation strings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)