### PR TITLE
feat(examples): writer_stdlib — consume zpp.writer trait from stdlib

### DIFF
--- a/examples/writer_buffered.zpp
+++ b/examples/writer_buffered.zpp
@@ -8,11 +8,11 @@
 /// underlying FileWriter when `flush()` runs. We then read the file
 /// back to confirm the bytes actually landed.
 ///
-/// (Note: this example was originally meant to use `zpp.writer.Writer`
-/// from the runtime library, but that module hasn't landed on this
-/// branch yet — only `zpp.trait`, `zpp.owned`, `zpp.contract`,
-/// `zpp.dyn_mod`, `zpp.async_mod`, `zpp.derive`. We instead hand-roll
-/// the same stack to demonstrate the pattern.)
+/// (For the "consume the stdlib trait" counterpart see
+/// `examples/writer_stdlib.zpp`, which uses `zpp.writer.Writer` +
+/// `zpp.writer.BufferedWriter(N)` directly. This file keeps the
+/// hand-rolled version so the trait/impl mechanics are visible without
+/// indirection through the runtime library.)
 ///
 /// Lowered Zig sketch:
 ///     const Writer_VTable = struct {

--- a/examples/writer_stdlib.zpp
+++ b/examples/writer_stdlib.zpp
@@ -1,0 +1,87 @@
+/// writer_stdlib.zpp — consume the stdlib `zpp.writer` Writer trait.
+///
+/// Teaches: how to plug a sink into the runtime-provided `Writer` fat
+/// pointer instead of hand-rolling your own (compare with
+/// `examples/writer_buffered.zpp`, which builds the same shape from
+/// scratch). Three things land here:
+///   1. `zpp.writer.stdout()` — write to the process's stdout via the trait.
+///   2. `zpp.writer.FileWriter` + `zpp.writer.BufferedWriter(N)` — stack a
+///      buffered wrapper over a file sink and observe coalesced flushes.
+///   3. `zpp.writer.print(w, fmt, args)` — formatted output with a fixed
+///      1024-byte stack buffer (no heap allocation).
+///
+/// The whole module is type-erased through `zpp.Dyn`, so a generic helper
+/// like `greet(w: zpp.writer.Writer, name: []const u8)` takes the fat
+/// pointer directly and works against every concrete sink.
+///
+/// Lowered Zig sketch:
+///     const w_stdout = blk: {
+///         var sw = zpp.writer.stdout();
+///         break :blk sw.writer();
+///     };
+///     try zpp.writer.print(w_stdout, "hello, {s}\n", .{"zigpp"});
+///
+///     var fw = zpp.writer.FileWriter.init(file);
+///     var bw = zpp.writer.BufferedWriter(64).init(fw.writer());
+///     const w = bw.writer();
+///     try zpp.writer.writeAll(w, "buffered ");
+///     try zpp.writer.print(w, "value={d}\n", .{42});
+///     try zpp.writer.flush(w);
+
+const std = @import("std");
+const zpp = @import("zpp");
+
+// Generic over `zpp.writer.Writer` — one function, every sink. The
+// trait is a fat pointer, so this does not monomorphize per concrete
+// writer type the way `impl Writer` would.
+fn greet(w: zpp.writer.Writer, name: []const u8) !void {
+    try zpp.writer.print(w, "hello, {s}!\n", .{name});
+}
+
+pub fn main() !void {
+    // 1) Stdout via the stdlib trait. `stdout()` returns a `StdoutWriter`
+    //    by value; `.writer()` materialises a comptime vtable and packs
+    //    it with `&sw` into a `Writer` fat pointer.
+    var sw = zpp.writer.stdout();
+    try greet(sw.writer(), "stdout");
+
+    // 2) File sink with a 64-byte buffered wrapper.
+    const tmp_path = "writer_stdlib.tmp";
+    const file = try std.fs.cwd().createFile(tmp_path, .{ .truncate = true, .read = true });
+    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer file.close();
+
+    var fw = zpp.writer.FileWriter.init(file);
+    var bw = zpp.writer.BufferedWriter(64).init(fw.writer());
+    const w = bw.writer();
+
+    // Five small writeAlls coalesce into the 64-byte buffer; nothing
+    // touches the file yet.
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        try zpp.writer.writeAll(w, "hi-");
+    }
+    // print() routes formatted output through the same trait. The
+    // formatter's 1024-byte stack buffer drains into the buffered
+    // writer, which in turn drains into the file when full.
+    try zpp.writer.print(w, "value={d}\n", .{42});
+    try zpp.writer.print(w, "{s}", .{"0123456789-0123456789-0123456789-0123456789-end\n"});
+
+    // Explicit flush drains anything still parked in the 64-byte
+    // staging area down through the file writer.
+    try zpp.writer.flush(w);
+
+    // Read the file back and report a checksum to confirm the bytes
+    // landed on disk through the full Writer → BufferedWriter →
+    // FileWriter chain.
+    try file.seekTo(0);
+    var read_buf: [256]u8 = undefined;
+    const n = try file.readAll(&read_buf);
+    const contents = read_buf[0..n];
+
+    std.debug.print("wrote {d} bytes via zpp.writer to '{s}'\n", .{ n, tmp_path });
+    std.debug.print("first 16: \"{s}\"\n", .{contents[0..@min(contents.len, 16)]});
+    const tail_start = if (contents.len >= 16) contents.len - 16 else 0;
+    std.debug.print("last 16:  \"{s}\"\n", .{contents[tail_start..]});
+    std.debug.print("(stdlib Writer trait; BufferedWriter coalesced; explicit flush drained the tail)\n", .{});
+}


### PR DESCRIPTION
## Summary

- Add **`examples/writer_stdlib.zpp`** that consumes the `zpp.writer` Writer trait that landed with #97 (Phase-2 stdlib). Demonstrates `zpp.writer.stdout()`, `FileWriter` + `BufferedWriter(64)` chained through the fat pointer, and `zpp.writer.print(w, fmt, args)` formatted output (no heap; 1024-byte stack staging).
- Refresh the stale comment block in **`examples/writer_buffered.zpp`** — it said `zpp.writer.Writer` hadn't landed yet, which is no longer true. Now it points readers at the new file as the "consume the stdlib trait" counterpart, keeping the hand-rolled version as the "see the trait/impl mechanics directly" counterpart.

The two examples now form a pair:
| File | Angle |
|---|---|
| `writer_buffered.zpp` | Hand-rolls `trait Writer` + `FileWriter` + `BufferedWriter` from scratch — trait/impl mechanics are visible. |
| `writer_stdlib.zpp` (new) | Consumes `zpp.writer.{Writer, FileWriter, BufferedWriter, stdout, print, writeAll, flush}` directly — shows what an end user writes. |

Closes the gap flagged in the test/example explore audit ("`zpp.writer.Writer` (landed in #97) lacks a dedicated example").

## Test plan

- [x] `zig build` — green
- [x] `zig build test` — green
- [x] `zig build check` — green (sema across all examples)
- [x] `zig build e2e` — new example lowers, builds, and runs; output ends with `hello, stdout!` then `wrote 72 bytes via zpp.writer to 'writer_stdlib.tmp'` and the buffered/flushed disk read-back.
- [ ] CI matrix (ubuntu / macos / windows) — to be validated by the PR build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)