### PR TITLE
refactor(bench): use writeAll for argument-free print calls

### DIFF
--- a/bench/bench.zig
+++ b/bench/bench.zig
@@ -31,10 +31,10 @@ pub fn main() !void {
     const w = &stdout_writer.interface;
     defer w.flush() catch {};
 
-    try w.print("# zpp lowering benchmarks\n\n", .{});
+    try w.writeAll("# zpp lowering benchmarks\n\n");
     try w.print("Compiled with mode={s}.\n\n", .{@tagName(@import("builtin").mode)});
-    try w.print("| decls | input bytes | output bytes | iters | total ms | µs / iter | bytes/sec |\n", .{});
-    try w.print("|------:|------------:|-------------:|------:|---------:|----------:|----------:|\n", .{});
+    try w.writeAll("| decls | input bytes | output bytes | iters | total ms | µs / iter | bytes/sec |\n");
+    try w.writeAll("|------:|------------:|-------------:|------:|---------:|----------:|----------:|\n");
 
     for (sizes, 0..) |n, i| {
         const iters = iters_for[i];
@@ -68,7 +68,7 @@ pub fn main() !void {
         );
     }
 
-    try w.print("\n_bytes/sec measured against input size, not output. Lowering output is normally 1.5x–3x larger than input due to vtable / thunk emission._\n", .{});
+    try w.writeAll("\n_bytes/sec measured against input size, not output. Lowering output is normally 1.5x–3x larger than input due to vtable / thunk emission._\n");
 }
 
 /// Build a synthetic source file with `n_decls` top-level declarations.


### PR DESCRIPTION
## Summary

Four `try w.print("...", .{})` calls in `bench/bench.zig` had empty argument tuples — they're just emitting fixed strings (the markdown header, two table rule lines, and the trailing footnote). `writeAll` is the idiomatic spelling for that and skips the format-string parse pass entirely.

No behavior change.

## What's in this PR

```diff
- try w.print("# zpp lowering benchmarks\n\n", .{});
+ try w.writeAll("# zpp lowering benchmarks\n\n");
  try w.print("Compiled with mode={s}.\n\n", .{@tagName(@import("builtin").mode)});
- try w.print("| decls | ... | bytes/sec |\n", .{});
- try w.print("|------:|...|----------:|\n", .{});
+ try w.writeAll("| decls | ... | bytes/sec |\n");
+ try w.writeAll("|------:|...|----------:|\n");
  ...
- try w.print("\n_bytes/sec measured against input size...emission._\n", .{});
+ try w.writeAll("\n_bytes/sec measured against input size...emission._\n");
```

The middle `print` on the `Compiled with mode=...` line stays — it has an argument.

## Test plan

- [x] `zig build bench` runs end-to-end (ReleaseFast)
- [x] Output is byte-identical to before — same markdown header, same table, same footnote:
  ```
  # zpp lowering benchmarks

  Compiled with mode=ReleaseFast.

  | decls | input bytes | output bytes | iters | total ms | µs / iter | bytes/sec |
  |------:|------------:|-------------:|------:|---------:|----------:|----------:|
  |    10 |        2687 |         7051 |   200 |   219.31 |    1096.5 |   2450446 |
  ...
  ```
- [x] `grep -rn '\.print(\"[^\"]*\", \.{})' compiler/ lib/ tools/ bench/` shows the only remaining hit is inside a string literal in `compiler/diagnostics.zig:239` (a `.noio` violation example), which is correct as-is.

## Notes

Tiny cosmetic refactor; not load-bearing. Bundling separately from any other change to keep the diff a single intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)