### PR TITLE
chore(compiler): remove dead `kw_for_kw` token variant

### DIFF
--- a/compiler/token.zig
+++ b/compiler/token.zig
@@ -95,7 +95,6 @@ pub const TokenKind = enum {
     // New Zig++ keywords
     kw_trait,
     kw_impl,
-    kw_for_kw, // intentionally unused; alias of kw_for
     kw_dyn,
     kw_using,
     kw_owned,


### PR DESCRIPTION
## Summary

`kw_for_kw` is declared in `Token.Kind` with the comment *"intentionally unused; alias of kw_for"*, but the variant is fully dead — no source text maps to it, no code consumes it, and it is not an alias of anything (the keyword `for` maps to `kw_for` directly).

```diff
     // New Zig++ keywords
     kw_trait,
     kw_impl,
-    kw_for_kw, // intentionally unused; alias of kw_for
     kw_dyn,
     kw_using,
```

## Why it's safe to remove

- **Lexer never produces it.** The keyword table at `compiler/token.zig:127–175` has no entry whose `kind` is `.kw_for_kw`. The string `"for"` maps to `kw_for`; nothing else maps anywhere near `kw_for_kw`.
- **Nothing reads it.** Project-wide grep:
  ```
  $ grep -rn 'kw_for_kw' --include='*.zig' compiler/ lib/ tools/ tests/
  compiler/token.zig:98:    kw_for_kw, // intentionally unused; alias of kw_for
  ```
  Just the declaration. No `.kw_for_kw` usage in parser, sema, lower, lsp, fmt, migrate, or tests.
- **The comment is wrong.** It calls itself an "alias of kw_for" but Zig enums don't have aliases — each variant gets its own discriminant, and there's no shim mapping one to the other.

## Test plan

- [x] `zig build test` → exit 0 (full unit + integration suite)
- [x] `zig build all` → exit 0 (build + test + check + examples + e2e + bench)
- [x] `git diff` is exactly 1 deletion in 1 file

## Notes

This is a 1-line cleanup; no behavior change. If the variant was kept as a deliberate placeholder for a future feature, please close this PR with a note and I can adjust the comment to say so explicitly instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)