### PR TITLE
docs: drop `zpp test` claims (not implemented) and fix mangled @effectsOf links in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * **lsp:** code-action auto-fix (Z0010 deinit stub, Z0040 method stubs) ([fb9fca1](https://github.com/nktkt/zigpp-lang/commit/fb9fca1179ffd408df74324e3e9e2b0cb64f2248))
 * **lsp:** WorkspaceEdit auto-fix for Z0010 + Z0040 ([8138606](https://github.com/nktkt/zigpp-lang/commit/81386062a85b5f22e05d11779c9d3dae02e23aa7))
-* **sema:** [@effects](https://github.com/effects)Of surfaces .custom("name") effects ([7a8ab83](https://github.com/nktkt/zigpp-lang/commit/7a8ab83d5fb26bbb39b5f479974b04bea15865e1))
-* **sema:** [@effects](https://github.com/effects)Of surfaces .custom("name") in lowered output ([37fc1d5](https://github.com/nktkt/zigpp-lang/commit/37fc1d5507eca3f4a32ff7c36ed8aac575045704))
+* **sema:** `@effectsOf` surfaces .custom("name") effects ([7a8ab83](https://github.com/nktkt/zigpp-lang/commit/7a8ab83d5fb26bbb39b5f479974b04bea15865e1))
+* **sema:** `@effectsOf` surfaces .custom("name") in lowered output ([37fc1d5](https://github.com/nktkt/zigpp-lang/commit/37fc1d5507eca3f4a32ff7c36ed8aac575045704))
 
 ## [0.1.31](https://github.com/nktkt/zigpp-lang/compare/v0.1.30...v0.1.31) (2026-04-29)
 
@@ -54,7 +54,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Features
 
-* **sema:** [@effects](https://github.com/effects)Of(f) queryable (round 4) ([9182e06](https://github.com/nktkt/zigpp-lang/commit/9182e06a778f15b24191a30379d4658ea98027a7))
+* **sema:** `@effectsOf`(f) queryable (round 4) ([9182e06](https://github.com/nktkt/zigpp-lang/commit/9182e06a778f15b24191a30379d4658ea98027a7))
 
 ## [0.1.26](https://github.com/nktkt/zigpp-lang/compare/v0.1.25...v0.1.26) (2026-04-29)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,7 +24,7 @@ Zig++ は Zig 0.15+ をベースにしたリサーチ言語です。名前付き
 
 Pre-alpha (v0.2)。v0.2 で構造的トレイト、トレイトメソッドのデフォルト本体、
 `.noasync` エフェクト軸、`Writer` 標準ライブラリトレイト、TaskGroup の
-キャンセル伝播、`zpp test` / `zpp explain --json` / `zpp init --template`
+キャンセル伝播、`zpp explain --json` / `zpp init --template`
 サブコマンド、`build.zpp`、フル機能の LSP が揃いました。言語表面は引き
 続き意図的に小さいまま、エンドツーエンドの守備範囲だけ広がっています。
 
@@ -117,10 +117,9 @@ zpp lower examples/hello_trait.zpp
   (`/full`、`/range`、`/full/delta`)、`inlayHint`、`foldingRange`、
   `implementation`、`callHierarchy`、`codeLens`
 - **CLI サブコマンド**: `zpp build / run / lower / fmt / check / watch / doc /
-  migrate / lsp / init / explain` に加え、v0.2 で追加された `zpp test`
-  (テストブロックを低下 + 実行)、`zpp explain --json` (IDE 向け機械可読
-  diagnostic explainer)、`zpp init --template lib | exe | plugin` (3 種の
-  プロジェクトひな形)
+  migrate / lsp / init / explain` に加え、v0.2 で追加された
+  `zpp explain --json` (IDE 向け機械可読 diagnostic explainer)、
+  `zpp init --template lib | exe | plugin` (3 種のプロジェクトひな形)
 - **`build.zpp`** — `build.zig` の薄いエイリアス。ソース横に `build.zpp` を
   置けばドライバが lowering してから `zig build` を呼びます
 - **Migrate +5 パターン** — `zpp-migrate` が新たに 5 種の `.zig` イディオム
@@ -167,14 +166,13 @@ zig build run -- help        # zpp CLI を呼ぶ
 
 ```
 zpp            メインドライバ: build / run / lower / fmt / check / watch / doc /
-               migrate / lsp / init / explain / test
+               migrate / lsp / init / explain
 zpp-fmt        フォーマッタ
 zpp-lsp        LSP サーバ (stdio JSON-RPC、VS Code 拡張から使用)
 zpp-doc        Markdown ドキュメント生成
 zpp-migrate    .zig -> .zpp 移行ヘルパー
 ```
 
-`zpp test` はツリー内の `test "..."` ブロックを低下して実行します。
 `zpp explain Z0030 --json` は IDE 向けの構造化ペイロードを出力します。
 `zpp init --template lib | exe | plugin` でひな形の形を選べます。
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ no implicit destructors, and no exceptions**. `.zpp` source compiles to
 
 Pre-alpha (v0.2). The v0.2 push landed structural traits, trait method
 default bodies, the `.noasync` effect axis, the `Writer` stdlib trait,
-TaskGroup cancellation, the `zpp test` / `zpp explain --json` /
+TaskGroup cancellation, the `zpp explain --json` /
 `zpp init --template` subcommands, `build.zpp`, and the full LSP feature
 set — language surface is still intentionally small but covers more
 ground end-to-end.
@@ -96,7 +96,7 @@ zpp lower examples/hello_trait.zpp
 - **End-to-end pipeline** verified: 10+ example programs compile and run through `zpp run` AND `zig build e2e`
 - **Fuzz-clean**: 83,000+ generated/mutated inputs through the parser/sema/lowerer with zero panics, leaks, or timeouts
 - **Full IDE feature set via `zpp-lsp`**: hover-with-explain, go-to-definition, find references, workspace symbol search, rename, document symbol (Outline view), keyword + decl-name completion, code-action quick-fixes (Explain Z####), semantic tokens (`/full`, `/range`, `/full/delta`), `inlayHint`, `foldingRange`, `implementation`, `callHierarchy`, and `codeLens`
-- **CLI subcommands**: `zpp build / run / lower / fmt / check / watch / doc / migrate / lsp / init / explain`, plus v0.2 additions: `zpp test` (lowers + executes test blocks), `zpp explain --json` (machine-readable diagnostic explainer for IDEs), and `zpp init --template lib | exe | plugin` (three project scaffolds)
+- **CLI subcommands**: `zpp build / run / lower / fmt / check / watch / doc / migrate / lsp / init / explain`, plus v0.2 additions: `zpp explain --json` (machine-readable diagnostic explainer for IDEs) and `zpp init --template lib | exe | plugin` (three project scaffolds)
 - **`build.zpp`** — thin alias over `build.zig`. Drop a `build.zpp` next to your sources and the driver lowers it before invoking `zig build`.
 - **Migrate +5 patterns** — `zpp-migrate` recognises five additional `.zig` idioms (arena-scoped `defer`, manual vtable structs, `errdefer`-paired `init`, and two more) and emits `.zpp` rewrites
 
@@ -140,14 +140,13 @@ The CLIs install under `zig-out/bin/`:
 
 ```
 zpp            main driver: build, run, lower, fmt, check, watch, doc, migrate,
-               lsp, init, explain, test
+               lsp, init, explain
 zpp-fmt        formatter
 zpp-lsp        LSP server (stdin/stdout JSON-RPC; used by the VS Code extension)
 zpp-doc        markdown doc generator
 zpp-migrate    .zig -> .zpp migration helper
 ```
 
-`zpp test` lowers and executes `test "..."` blocks across a tree.
 `zpp explain Z0030 --json` emits a structured payload for IDE consumers.
 `zpp init --template lib | exe | plugin` picks the scaffold shape.
 


### PR DESCRIPTION
## Summary

Two unrelated documentation accuracy fixes that surfaced while auditing the v0.2 README refresh (#107) and the changelog.

### `zpp test` is not implemented

README.md (English) and README.ja.md (Japanese) both list `zpp test` as a v0.2 subcommand that "lowers + executes test blocks". The binary does not implement it:

```sh
$ ./zig-out/bin/zpp test
zpp: unknown subcommand 'test'
```

`tools/zpp.zig`'s `Subcommand` enum lists `build, run, lower, fmt, check, watch, doc, migrate, lsp, init, explain, version, help` — no `.test`. PR #107 documented the subcommand prematurely. Removed from four sites in each README:

- Status section's v0.2 push narrative
- "CLI subcommands" feature bullet
- The CLI table (`lsp, init, explain, test` → `lsp, init, explain`)
- The standalone one-liner description after the CLI table

The other two v0.2 CLI additions — `zpp explain --json` and `zpp init --template` — are real and stay documented.

### CHANGELOG `@effectsOf` mangled into a broken link

Three CHANGELOG entries (v0.1.27 round 4, v0.1.32 release) had `@effectsOf` mangled by release-please's auto-linker into:

```
[@effects](https://github.com/effects)Of
```

— a markdown link to a nonexistent GitHub user `@effects`, with `Of` left as plain text outside the link. Replaced with `\`@effectsOf\`` on lines 21, 22, and 57 so the rendered changelog correctly reads `\`@effectsOf\` surfaces .custom("name") effects` etc.

## Test plan

- [x] `./zig-out/bin/zpp test` confirmed to fail with `unknown subcommand 'test'`
- [x] grep confirmed no other docs (LANGUAGE.md, MANIFESTO.md, ROADMAP.md, docs/) reference `zpp test`
- [x] No code changes; pure documentation
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)