### PR TITLE
docs(diagnostics): add Z0002 (structural impl missing method)

### DIFF
--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -22,6 +22,7 @@ auto-applicable quick-fix (called out below).
 | Code  | Name                                                 | Axis                  |
 | ----- | ---------------------------------------------------- | --------------------- |
 | Z0001 | unknown trait                                        | Traits & `impl`       |
+| Z0002 | structural trait method missing on type              | Traits & `impl`       |
 | Z0010 | owned struct missing deinit                          | Ownership             |
 | Z0011 | `using` target has no deinit                         | Ownership             |
 | Z0020 | use after move                                       | Move / borrow         |
@@ -65,6 +66,43 @@ fn dispatch(g: dyn Greeter) void { g.vtable.greet(g.ptr); }
 ```
 
 Test: `tests/diagnostics/diags.zig`.
+
+### Z0002 — structural trait method missing on type
+
+Traits declared with `: structural` are satisfied by *matching method
+shapes* on the target type — no explicit `impl` block is required.
+When you do write `impl T for X { ... }` for a structural `T`, every
+method named in the impl block must correspond to an existing method
+on `X` (the impl block re-exports those methods through the trait's
+vtable). Missing-from-the-trait methods are allowed (that's the whole
+point of structural), but missing-from-the-type methods are not.
+
+This is the dual of Z0040 — Z0040 fires when a *nominal* impl is
+missing methods the trait requires; Z0002 fires when a *structural*
+impl is missing methods on the type the impl wants to re-export.
+
+```zig
+trait Greeter : structural { fn greet(self) void; }
+const Friendly = struct { name: []const u8 };
+impl Greeter for Friendly {
+    fn greet(self) void { _ = self; }   // Friendly has no greet → Z0002
+}
+```
+
+Fix — add the listed method(s) to the struct definition, or drop the
+impl block entirely (structural traits don't need one):
+
+```zig
+const Friendly = struct {
+    name: []const u8,
+    pub fn greet(self: *@This()) void { _ = self; }
+};
+// No impl block required — structural traits pick this up.
+```
+
+See: `examples/structural_trait.zpp` (compliant example),
+`tests/diagnostics/diags.zig` (3 fixtures covering the trigger,
+the matching-method case, and the no-impl case).
 
 ### Z0040 — impl is missing trait method(s)
 


### PR DESCRIPTION
## Summary

PR #118 (just merged) added `docs/src/diagnostics.md` with a section per Z-code, but **Z0002 was overlooked**:

- The quick-reference table jumps `Z0001 → Z0010`, omitting Z0002.
- No per-code section exists under "Traits and `impl`".

The code itself is fully implemented and tested:

| Surface | Where |
|---|---|
| Enum + `id()` | `compiler/diagnostics.zig:48,69` |
| Hint + canonical explain text | `compiler/diagnostics.zig:134-165` |
| Sema check | `compiler/sema.zig:115, 219-253` |
| Diagnostic tests | `tests/diagnostics/diags.zig:175-238` (3 fixtures) |
| CLI surface | `zpp explain Z0002` returns the full canonical text |
| Example | `examples/structural_trait.zpp` |

So the only thing missing was the user-facing markdown reference page. This PR closes that gap.

## Changes

- Add a `Z0002` row to the **Quick reference** table (between Z0001 and Z0010), tagged `Traits & impl`.
- Add a `### Z0002 — structural trait method missing on type` section under **Traits and `impl`** (between Z0001 and Z0040), mirroring the surrounding style:
  - Short prose explainer noting it's the dual of Z0040.
  - Trigger snippet matching the canonical `explain` body.
  - Fix snippet showing the natural structural-trait fix (drop the impl, define the method on the type).
  - "See:" line linking to `examples/structural_trait.zpp` and `tests/diagnostics/diags.zig`.

No behavioural changes; pure docs.

## Test plan

- [x] `zig build test` — green
- [x] `zpp explain Z0002` returns the canonical explain text (already worked; this PR just makes the markdown match)
- [x] Visual review of the rendered table + section

🤖 Generated with [Claude Code](https://claude.com/claude-code)