### PR TITLE
docs: v0.2 release shakeout — re-document `zpp test`, correct bench / Phase 5 / Z0011 claims

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -117,7 +117,8 @@ zpp lower examples/hello_trait.zpp
   (`/full`、`/range`、`/full/delta`)、`inlayHint`、`foldingRange`、
   `implementation`、`callHierarchy`、`codeLens`
 - **CLI サブコマンド**: `zpp build / run / lower / fmt / check / watch / doc /
-  migrate / lsp / init / explain` に加え、v0.2 で追加された
+  migrate / test / lsp / init / explain` に加え、v0.2 で追加された
+  `zpp test` (各 `.zpp` を lower し `zig test` で実行)、
   `zpp explain --json` (IDE 向け機械可読 diagnostic explainer)、
   `zpp init --template lib | exe | plugin` (3 種のプロジェクトひな形)
 - **`build.zpp`** — `build.zig` の薄いエイリアス。ソース横に `build.zpp` を
@@ -137,7 +138,7 @@ zigpp/
   tools/               zpp CLI + fmt / lsp / doc / migrate (init --template 用 templates/ を含む)
   examples/            各構文要素を網羅した .zpp プログラム (build_zpp/, multi_file/, cli/ を含む)
   examples-consumer/   `zig fetch` で `zpp` ランタイムを取り込む下流の Zig プロジェクト例
-  bench/               マイクロベンチ (dispatch / derive / TaskGroup)
+  bench/               マイクロベンチ (compileToString: parse + sema + lower)
   tests/               compile / diagnostic / snapshot / behavior / no-hidden-alloc / fuzz
   vscode/              VS Code 拡張 (TextMate grammar + LSP client + snippets)
   docs/                mdBook ドキュメントソース (GitHub Pages へデプロイ)
@@ -166,13 +167,14 @@ zig build run -- help        # zpp CLI を呼ぶ
 
 ```
 zpp            メインドライバ: build / run / lower / fmt / check / watch / doc /
-               migrate / lsp / init / explain
+               migrate / test / lsp / init / explain
 zpp-fmt        フォーマッタ
 zpp-lsp        LSP サーバ (stdio JSON-RPC、VS Code 拡張から使用)
 zpp-doc        Markdown ドキュメント生成
 zpp-migrate    .zig -> .zpp 移行ヘルパー
 ```
 
+`zpp test [paths...]` は各 `.zpp` を `.zpp-cache/<rel>.zig` に lower し、それぞれに `zig test` を走らせます (`--filter <p>` / `--release` / `-v`)。
 `zpp explain Z0030 --json` は IDE 向けの構造化ペイロードを出力します。
 `zpp init --template lib | exe | plugin` でひな形の形を選べます。
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ zpp lower examples/hello_trait.zpp
 - **End-to-end pipeline** verified: 10+ example programs compile and run through `zpp run` AND `zig build e2e`
 - **Fuzz-clean**: 83,000+ generated/mutated inputs through the parser/sema/lowerer with zero panics, leaks, or timeouts
 - **Full IDE feature set via `zpp-lsp`**: hover-with-explain, go-to-definition, find references, workspace symbol search, rename, document symbol (Outline view), keyword + decl-name completion, code-action quick-fixes (Explain Z####), semantic tokens (`/full`, `/range`, `/full/delta`), `inlayHint`, `foldingRange`, `implementation`, `callHierarchy`, and `codeLens`
-- **CLI subcommands**: `zpp build / run / lower / fmt / check / watch / doc / migrate / lsp / init / explain`, plus v0.2 additions: `zpp explain --json` (machine-readable diagnostic explainer for IDEs) and `zpp init --template lib | exe | plugin` (three project scaffolds)
+- **CLI subcommands**: `zpp build / run / lower / fmt / check / watch / doc / migrate / test / lsp / init / explain`, plus v0.2 additions: `zpp test` (lowers each `.zpp` and runs `zig test` against it), `zpp explain --json` (machine-readable diagnostic explainer for IDEs) and `zpp init --template lib | exe | plugin` (three project scaffolds)
 - **`build.zpp`** — thin alias over `build.zig`. Drop a `build.zpp` next to your sources and the driver lowers it before invoking `zig build`.
 - **Migrate +5 patterns** — `zpp-migrate` recognises five additional `.zig` idioms (arena-scoped `defer`, manual vtable structs, `errdefer`-paired `init`, and two more) and emits `.zpp` rewrites
 
@@ -111,7 +111,7 @@ zigpp/
   tools/               zpp CLI plus fmt, lsp, doc, migrate (with templates/ for `init --template`)
   examples/            .zpp programs covering each construct, including build_zpp/, multi_file/, cli/
   examples-consumer/   sample downstream Zig project that imports the `zpp` runtime via `zig fetch`
-  bench/               microbenchmarks (dispatch, derive, TaskGroup)
+  bench/               microbenchmarks (compileToString: parse + sema + lower)
   tests/               compile, diagnostic, snapshot, behavior, no-hidden-alloc, fuzz
   vscode/              VS Code extension (TextMate grammar + LSP client + snippets)
   docs/                mdBook documentation source (deployed to GitHub Pages)
@@ -140,13 +140,14 @@ The CLIs install under `zig-out/bin/`:
 
 ```
 zpp            main driver: build, run, lower, fmt, check, watch, doc, migrate,
-               lsp, init, explain
+               test, lsp, init, explain
 zpp-fmt        formatter
 zpp-lsp        LSP server (stdin/stdout JSON-RPC; used by the VS Code extension)
 zpp-doc        markdown doc generator
 zpp-migrate    .zig -> .zpp migration helper
 ```
 
+`zpp test [paths...]` lowers every `.zpp` under the given paths into `.zpp-cache/<rel>.zig` and runs `zig test` against each (`--filter <p>`, `--release`, `-v`).
 `zpp explain Z0030 --json` emits a structured payload for IDE consumers.
 `zpp init --template lib | exe | plugin` picks the scaffold shape.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Phases 0-7 are substantially complete. The remaining Phase 6 item (`zpp` depende
 | Phase 2 — Trait System                  | ✅ done    | structural opt-in, Writer trait, default methods |
 | Phase 3 — Explicit RAII & Ownership     | ✅ done    | Z0010/Z0011/Z0020/Z0021 firing |
 | Phase 4 — dyn Trait & Plugin ABI        | ✅ done    | extern_plugin example loads |
-| Phase 5 — Effect System                 | ✅ done    | 6 axes (alloc, io, panic, async, custom, .nocustom) |
+| Phase 5 — Effect System                 | ✅ done    | 5 axes (alloc, io, panic, async, custom) with paired `no*` denials |
 | Phase 6 — Package, Build, Docs          | ⚠️ partial | build.zpp + HTML + snapshot gate done; semver dep resolution open |
 | Phase 7 — Concurrency                   | ✅ done    | TaskGroup + cancellation; Zig 0.17 I/O migration pending upstream |
 | Phase 8 — Stabilization (1.0)           | ⏳ not started | next milestone after Phase 6 closure |

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -23,7 +23,7 @@ auto-applicable quick-fix (called out below).
 | ----- | ---------------------------------------------------- | --------------------- |
 | Z0001 | unknown trait                                        | Traits & `impl`       |
 | Z0010 | owned struct missing deinit                          | Ownership             |
-| Z0011 | `using` target has no deinit                         | Ownership             |
+| Z0011 | `using` target lacks deinit                         | Ownership             |
 | Z0020 | use after move                                       | Move / borrow         |
 | Z0021 | borrow invalidated by move                           | Move / borrow         |
 | Z0030 | function violates declared effect                    | Effects               |
@@ -124,7 +124,7 @@ real cleanup.
 See: `examples/owned_file.zpp` (compliant example),
 `tests/diagnostics/diags.zig` (negative fixture).
 
-### Z0011 — `using` target has no deinit
+### Z0011 — `using` target lacks deinit
 
 `using x = expr;` lowers to `var x = expr; defer x.deinit();`. The
 type of `expr` must therefore have a `deinit` method, otherwise the

--- a/examples-consumer/README.md
+++ b/examples-consumer/README.md
@@ -61,7 +61,7 @@ and uses it to lower `src/main.zpp` at build time:
 const zpp_dep = b.dependency("zigpp", .{ .target = target, .optimize = optimize });
 const lower = b.addRunArtifact(zpp_dep.artifact("zpp"));
 lower.addArg("lower");
-lower.addArg("src/main.zpp");
+lower.addFileArg(b.path("src/main.zpp"));
 const lowered = lower.captureStdOut();
 // ...wrap in addWriteFiles to give it a stable name, then build as exe.
 ```


### PR DESCRIPTION
## Summary

Five small accuracy fixes that surfaced after the v0.1.34 (v0.2) release.

### `zpp test` re-documented (README.md, README.ja.md)

PR #120 stripped `zpp test` from both READMEs on the premise that the subcommand was unimplemented. #96 had landed the implementation in parallel — `tools/zpp_test.zig` is in-tree and `tools/zpp.zig:32` wires the `.@\"test\"` variant into `Subcommand`. Restored in three sites per file:

- The CLI-subcommand feature bullet (added back to the slash-list and the v0.2 additions)
- The CLI binary table (re-inserted `test` between `migrate` and `lsp`)
- The standalone one-paragraph description after the binary table, including the actual flags surfaced by `zpp test --help`: `--filter <p>`, `--release`, `-v`

### bench coverage one-liner (README.md, README.ja.md)

The `bench/` row in the layout said "microbenchmarks (dispatch, derive, TaskGroup)". `bench/bench.zig` actually times `compileToString` on synthetic inputs of increasing size — it's a parse+sema+lower pipeline benchmark. The synthesized source touches dispatch and derive, but the bench doesn't isolate them. Rewrote to match what's measured.

### ROADMAP.md Phase 5 axes count

The Phase 5 row said `6 axes (alloc, io, panic, async, custom, .nocustom)`. `.nocustom` is the negation of `.custom`, not an independent axis — `compiler/ast.zig:43` pairs each axis with a `no*` denial. README correctly says \"5 axes\". Aligned ROADMAP.

### docs/src/diagnostics.md Z0011 wording

Both the quick-reference row and the section heading still said `\`using\` target has no deinit`. The compiler's `explain()` text and inline summary have said \"lacks deinit\" since #112 (now in 0.1.34). Synced the docs to the compiler.

### examples-consumer/README.md stale build.zig snippet

The snippet on line 64 used `lower.addArg(\"src/main.zpp\")`, but the actual `examples-consumer/build.zig:14` calls `lower.addFileArg(b.path(\"src/main.zpp\"))`. Updated so copy-pasting it actually compiles.

## What I rejected from the audit

- **CHANGELOG 0.1.34 duplicates** (lines 38–39, 42–43, 50–51) — release-please-managed; manual edits churn.
- **CHANGELOG line 44** — release-please re-mangled `@effectsOf` into `[@effects](https://github.com/effects)Of` *inside the description of #120*, which fixed the same bug. Real but auto-regenerated; needs a release-please config tweak, not a docs edit.
- **VS Code TextMate grammar gaps** (`invariant`, `anyerror`, etc., missing; `noinline`, `packed`, `usingnamespace` extra) — broader judgment call about Zig-passthrough keywords.
- **init-templates plugin README minor inconsistencies** — cosmetic only.
- **docs/src/diagnostics.md missing Z0002** — needs a new section, larger change.

## Test plan

- [x] `tools/zpp.zig:32` confirmed `.@\"test\"` variant exists in `Subcommand`
- [x] `tools/zpp_test.zig` confirmed in-tree
- [x] `bench/bench.zig` confirmed to only measure `compileToString` (no dispatch/derive/TaskGroup isolation)
- [x] `compiler/ast.zig:43` `EffectKind` confirmed to pair 5 axes with `no*` denials
- [x] `compiler/diagnostics.zig` confirmed to use \"lacks deinit\" (post #112)
- [x] `examples-consumer/build.zig:14` confirmed to use `addFileArg(b.path(...))`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)