### PR TITLE
feat(vscode): grammar + snippets for v0.2 features (structural / .noasync / .custom)

### DIFF
--- a/vscode/snippets/zigpp.json
+++ b/vscode/snippets/zigpp.json
@@ -76,8 +76,8 @@
   },
   "effects": {
     "prefix": "effects",
-    "body": ["effects(${1|.alloc,.noalloc,.io,.noio,.panic|}$0)"],
-    "description": "Effect annotation (sema-linted)."
+    "body": ["effects(${1|.alloc,.noalloc,.io,.noio,.panic,.nopanic,.async,.noasync|}$0)"],
+    "description": "Effect annotation (sema-linted). For custom effects use the effects_custom snippet."
   },
   "extern interface": {
     "prefix": "externi",
@@ -130,6 +130,25 @@
     "prefix": "effects_pure",
     "body": ["effects(.noalloc, .noio)"],
     "description": "Pure effect annotation: forbids allocation and I/O."
+  },
+  "effects_custom": {
+    "prefix": "effects_custom",
+    "body": ["effects(.custom(\"${1:effect_name}\"))"],
+    "description": "User-defined effect tag; flows through @effectsOf and is checkable via .nocustom(\"X\")."
+  },
+  "effects_of": {
+    "prefix": "effects_of",
+    "body": ["@effectsOf(${1:fn_name})"],
+    "description": "Comptime-query the inferred effect set of a same-file fn (returns []const u8)."
+  },
+  "structural_trait": {
+    "prefix": "structural_trait",
+    "body": [
+      "trait ${1:Name} : structural {",
+      "    fn ${2:method}(self) ${3:void};",
+      "}"
+    ],
+    "description": "Structural trait — satisfied by any type with matching method shapes; no impl block required."
   },
   "pub_trait": {
     "prefix": "pub_trait",

--- a/vscode/syntaxes/zigpp.tmLanguage.json
+++ b/vscode/syntaxes/zigpp.tmLanguage.json
@@ -140,7 +140,7 @@
       "patterns": [
         {
           "name": "keyword.zigpp.extension",
-          "match": "\\b(trait|impl|dyn|using|owned|own|move|where|requires|ensures|effects|derive|interface)\\b"
+          "match": "\\b(trait|impl|dyn|using|owned|own|move|where|requires|ensures|effects|derive|interface|structural)\\b"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Refresh the TextMate grammar and snippets file shipped with the VS Code extension so they cover the v0.2 effect axes and structural traits. Three concrete gaps were found vs. the compiler & sema code that has landed:

| Surface | Gap | File:line |
|---|---|---|
| Grammar | `structural` not in extension keywords → `: structural` on a trait decl rendered as plain text | `vscode/syntaxes/zigpp.tmLanguage.json:143` |
| Snippet | `effects` choice list stopped at `.panic` (missing `.nopanic`, `.async`, `.noasync`) | `vscode/snippets/zigpp.json:79` |
| Snippet | No scaffolds for `.custom("X")`, `@effectsOf(fn)`, or `trait T : structural` | `vscode/snippets/zigpp.json` |

## Changes

**`vscode/syntaxes/zigpp.tmLanguage.json`** — append `structural` to the `keyword.zigpp.extension` regex so the modifier is highlighted as a keyword wherever it appears (mainly `trait Foo : structural { ... }`).

**`vscode/snippets/zigpp.json`** —
- Extend the `effects` snippet choice list to `.alloc, .noalloc, .io, .noio, .panic, .nopanic, .async, .noasync` and update its description to point at the new `effects_custom` snippet.
- Add `effects_custom` → `effects(.custom(\"\${1:effect_name}\"))`.
- Add `effects_of` → `@effectsOf(\${1:fn_name})`.
- Add `structural_trait` → full `trait Name : structural { fn method(self) void; }` scaffold.

## Test plan

- [x] `python3 -m json.tool` parses both JSON files cleanly
- [x] `npm run compile` under `vscode/` is green (CI's `vscode-extension` job runs the same `tsc -p ./`)
- [x] `zig build` is unaffected (no compiler-side changes)
- [ ] CI matrix — to be validated by the PR build

🤖 Generated with [Claude Code](https://claude.com/claude-code)