### PR TITLE
docs(examples): drop stale notes that contradict landed features

### DIFF
--- a/examples/effects_nopanic_demo.zpp
+++ b/examples/effects_nopanic_demo.zpp
@@ -8,10 +8,8 @@
 /// `.nopanic` declaration that contradicts the inferred set is rejected
 /// at sema time with Z0030.
 ///
-/// (Note: this example originally targeted `.noasync` enforcement, but
-/// that effect kind is not on this branch — only `.nopanic`, `.noalloc`,
-/// `.noio` and `custom`/`nocustom` are available. We use `.nopanic` to
-/// demonstrate the same shape.)
+/// See `examples/effects_noasync.zpp` for the same shape applied to
+/// `.noasync` (suspension-point enforcement).
 ///
 /// Lowered Zig sketch:
 ///     // Effect annotations are erased post-sema; the body lowers to

--- a/examples/structural_advanced.zpp
+++ b/examples/structural_advanced.zpp
@@ -7,10 +7,9 @@
 /// resolves through normal Zig method lookup. Each call site of
 /// `welcome(impl Greeter, ...)` is monomorphized to the concrete type.
 ///
-/// (Note: this example originally targeted *structural* traits — opt-in
-/// duck typing — but that feature has not landed on this branch. We
-/// instead exercise multi-param trait dispatch, which is also a less
-/// covered surface.)
+/// See `examples/structural_trait.zpp` for the `: structural` opt-in
+/// duck-typing variant. This file focuses on multi-parameter trait
+/// dispatch through a nominal trait, which is a less-covered surface.
 ///
 /// Lowered Zig sketch:
 ///     const Tweet = struct {

--- a/examples/writer_buffered.zpp
+++ b/examples/writer_buffered.zpp
@@ -31,7 +31,6 @@
 ///     };
 
 const std = @import("std");
-const zpp = @import("zpp");
 
 trait Writer {
     fn write(self, bytes: []const u8) anyerror!void;


### PR DESCRIPTION
## Summary

Three example doc-comment cleanups. No code change. Each note in the preamble contradicted a feature that has actually landed on `main`.

## What's in this PR

### 1. `effects_nopanic_demo.zpp` — `.noasync` is on this branch

The preamble said:

> *(Note: this example originally targeted `.noasync` enforcement, but that effect kind is not on this branch — only `.nopanic`, `.noalloc`, `.noio` and `custom`/`nocustom` are available. We use `.nopanic` to demonstrate the same shape.)*

`.noasync` is fully implemented:

- `compiler/ast.zig:43` — `EffectKind` includes `noasync`
- `compiler/parser.zig:689` — parser maps `noasync` text to the variant
- `compiler/sema.zig:1079+` — `checkAsyncEffectInference` fires Z0030 on contradiction
- `examples/effects_noasync.zpp` — peer example exists
- `tests/lowering/inputs/effects_noasync.zpp` + matching snapshot

Replaced the note with a one-line forward reference to `examples/effects_noasync.zpp`.

### 2. `structural_advanced.zpp` — structural traits are on this branch

The preamble said:

> *(Note: this example originally targeted *structural* traits — opt-in duck typing — but that feature has not landed on this branch.)*

Structural traits landed in #91:

- `compiler/ast.zig:150-156` — `is_structural: bool` on `TraitDecl`
- `compiler/parser.zig:235-262` — parses `: structural`
- `compiler/sema.zig:32-37` — `structural_traits` map relaxes Z0040
- `examples/structural_trait.zpp` is the dedicated demo

Replaced with a forward reference to `examples/structural_trait.zpp` plus a one-line explanation of what *this* file uniquely covers (multi-parameter nominal-trait dispatch).

### 3. `writer_buffered.zpp` — drop dead `@import("zpp")`

The example imports `const zpp = @import("zpp");` but never references the `zpp` namespace anywhere in the file body. The doc preamble (line 12-14) explicitly says this example *"keeps it self-contained"* by rolling its own `Writer` trait — the import contradicts the file's stated pedagogical intent and is dead.

Removed the import.

## Test plan

- [x] `zig build all` (build + test + check + examples + e2e + bench) → exit 0
- [x] `git diff` is 9 lines across 3 example files; comments + 1 unused import; no executable code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)